### PR TITLE
Add environment variable fallback for email credentials

### DIFF
--- a/Application/emailextract.py
+++ b/Application/emailextract.py
@@ -11,6 +11,27 @@ SENDER_EMAIL = "mailbox.noreply@cibc.com"
 START_DATE = "09-Feb-2025"  # Format: DD-Mon-YYYY
 END_DATE = "16-jun-2025"    # Format: DD-Mon-YYYY
 
+def load_credentials():
+    """Load credentials from credentials.yml or environment variables."""
+    base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    credentials_path = os.path.join(base_dir, "credentials.yml")
+
+    user = os.getenv("EMAIL_USER")
+    password = os.getenv("EMAIL_PASS")
+
+    if os.path.exists(credentials_path):
+        with open(credentials_path) as f:
+            creds = yaml.safe_load(f)
+            user = creds.get("user", user)
+            password = creds.get("password", password)
+
+    if not user or not password:
+        raise ValueError(
+            "Email credentials not provided. Set EMAIL_USER and EMAIL_PASS or create credentials.yml"
+        )
+
+    return user, password
+
 def load_config():
     """Load the configuration file to get bank keywords."""
     config_file = os.path.join(os.path.dirname(__file__), "config.yml")
@@ -54,13 +75,8 @@ def fetch_emails_by_date_range():
     imap_url = 'imap.gmail.com'
     my_mail = imaplib.IMAP4_SSL(imap_url)
 
-    # ✅ Get credentials
-    base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-    credentials_path = os.path.join(base_dir, "credentials.yml")
-    with open(credentials_path) as f:
-        my_credentials = yaml.load(f, Loader=yaml.FullLoader)
-    
-    user, password = my_credentials["user"], my_credentials["password"]
+    # ✅ Load credentials from file or environment
+    user, password = load_credentials()
 
     # ✅ Load configuration for keyword matching
     config = load_config()

--- a/Application/extracteur.py
+++ b/Application/extracteur.py
@@ -9,6 +9,27 @@ from email.header import decode_header
 SENDER_EMAIL = "info@neofinancial.com"  # Modifiez cette valeur selon l'expéditeur souhaité
 EMAIL_POSITION = -3  # -1 pour le dernier email, -2 pour l'avant-dernier, etc.
 
+def load_credentials():
+    """Load credentials from credentials.yml or environment variables."""
+    base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    credentials_path = os.path.join(base_dir, "credentials.yml")
+
+    user = os.getenv("EMAIL_USER")
+    password = os.getenv("EMAIL_PASS")
+
+    if os.path.exists(credentials_path):
+        with open(credentials_path) as f:
+            creds = yaml.safe_load(f)
+            user = creds.get("user", user)
+            password = creds.get("password", password)
+
+    if not user or not password:
+        raise ValueError(
+            "Email credentials not provided. Set EMAIL_USER and EMAIL_PASS or create credentials.yml"
+        )
+
+    return user, password
+
 def extract_email_body(my_msg):
     """Extracts clean text from an email body (either plain text or HTML)."""
     body = None
@@ -33,13 +54,8 @@ def fetch_email_text():
     imap_url = 'imap.gmail.com'
     my_mail = imaplib.IMAP4_SSL(imap_url)
 
-    # ✅ Get the absolute path to 'credentials.yml'
-    base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-    credentials_path = os.path.join(base_dir, "credentials.yml")
-    with open(credentials_path) as f:
-        my_credentials = yaml.load(f, Loader=yaml.FullLoader)
-    
-    user, password = my_credentials["user"], my_credentials["password"]
+    # ✅ Load credentials from file or environment
+    user, password = load_credentials()
 
     # ✅ Login & Select Inbox
     my_mail.login(user, password)

--- a/README.md
+++ b/README.md
@@ -77,15 +77,20 @@ EXPENSETRACKER/
    pip install -r requirements.txt
    ```
 
-3. **Configure credentials**
-   Add your email credentials to `credentials.yml`:
+3. **Provide credentials**
+   You can either create a `credentials.yml` file or use environment variables.
+
+   **Option A - `credentials.yml`**
 
    ```yaml
-   email:
-     address: youremail@example.com
-     password: yourpassword
-     imap_server: imap.gmail.com
+   user: "youremail@example.com"
+   password: "yourapppassword"
    ```
+
+   **Option B - environment variables**
+
+   Set `EMAIL_USER` and `EMAIL_PASS` in your environment. You may place them in a
+   local `.env` file and run `source .env` before starting the application.
 
 4. **Edit `config.yml`** with:
 

--- a/credentials.yml
+++ b/credentials.yml
@@ -1,5 +1,5 @@
-# config.yaml file
+# Example credentials file
 
-user: "fallmamadou151@gmail.com"
-password: "rbjnyfjposzukcki"
+user: "youremail@example.com"
+password: "yourapppassword"
 


### PR DESCRIPTION
## Summary
- add environment variable loader in `extracteur.py` and `emailextract.py`
- sanitize `credentials.yml` with placeholder values
- document credential options in README

## Testing
- `python -m py_compile Application/extracteur.py Application/emailextract.py`
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68673b90f0f8832bbee27474418ce7d7