### PR TITLE
Add env-based email credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Ignore environment configuration
+.env
+
+# Ignore local credentials if changed
+credentials.yml
+
+# Ignore Python cache
+__pycache__/

--- a/Application/emailextract.py
+++ b/Application/emailextract.py
@@ -57,10 +57,18 @@ def fetch_emails_by_date_range():
     # ✅ Get credentials
     base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
     credentials_path = os.path.join(base_dir, "credentials.yml")
-    with open(credentials_path) as f:
-        my_credentials = yaml.load(f, Loader=yaml.FullLoader)
-    
-    user, password = my_credentials["user"], my_credentials["password"]
+
+    user = os.getenv("EMAIL_USER")
+    password = os.getenv("EMAIL_PASS")
+
+    if os.path.exists(credentials_path):
+        with open(credentials_path) as f:
+            my_credentials = yaml.safe_load(f)
+            user = user or my_credentials.get("user")
+            password = password or my_credentials.get("password")
+
+    if not user or not password:
+        raise ValueError("Email credentials not provided. Set EMAIL_USER and EMAIL_PASS environment variables or update credentials.yml")
 
     # ✅ Load configuration for keyword matching
     config = load_config()

--- a/Application/extracteur.py
+++ b/Application/extracteur.py
@@ -33,13 +33,21 @@ def fetch_email_text():
     imap_url = 'imap.gmail.com'
     my_mail = imaplib.IMAP4_SSL(imap_url)
 
-    # ✅ Get the absolute path to 'credentials.yml'
+    # ✅ Get credentials either from credentials.yml or environment variables
     base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
     credentials_path = os.path.join(base_dir, "credentials.yml")
-    with open(credentials_path) as f:
-        my_credentials = yaml.load(f, Loader=yaml.FullLoader)
-    
-    user, password = my_credentials["user"], my_credentials["password"]
+
+    user = os.getenv("EMAIL_USER")
+    password = os.getenv("EMAIL_PASS")
+
+    if os.path.exists(credentials_path):
+        with open(credentials_path) as f:
+            my_credentials = yaml.safe_load(f)
+            user = user or my_credentials.get("user")
+            password = password or my_credentials.get("password")
+
+    if not user or not password:
+        raise ValueError("Email credentials not provided. Set EMAIL_USER and EMAIL_PASS environment variables or update credentials.yml")
 
     # ✅ Login & Select Inbox
     my_mail.login(user, password)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# ExpenseTracker
+
+This project extracts transaction data from emails and stores it in a local SQLite database.
+
+## Setup
+
+1. **Provide email credentials** used by the extraction scripts.
+   - Either edit `credentials.yml` with your Gmail address and app password.
+   - Or set the environment variables `EMAIL_USER` and `EMAIL_PASS`. A `.env` file can be used with tools such as `python-dotenv`.
+
+   Example `.env` file:
+   ```
+   EMAIL_USER=your_email@example.com
+   EMAIL_PASS=your_app_password
+   ```
+
+2. Install Python dependencies (if not already available):
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Run the extraction scripts located in the `Application` folder.
+

--- a/credentials.yml
+++ b/credentials.yml
@@ -1,5 +1,5 @@
-# config.yaml file
+# Example credentials file. Replace with real values or use environment variables.
 
-user: "fallmamadou151@gmail.com"
-password: "rbjnyfjposzukcki"
+user: "your_email@example.com"
+password: "your_password"
 


### PR DESCRIPTION
## Summary
- add environment variable fallback for Gmail credentials
- update sample `credentials.yml`
- add project README with setup notes
- ignore local env files and Python cache

## Testing
- `python3 -m py_compile Application/extracteur.py Application/emailextract.py`

------
https://chatgpt.com/codex/tasks/task_e_68697985717c832b9ed3513ead9e3639