### PR TITLE
Update README for node setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This project extracts transaction data from emails and stores it in a local SQLi
    ```
    EMAIL_USER=your_email@example.com
    EMAIL_PASS=your_app_password
+   PORT=5000  # optional server port
    ```
 
 2. Install Python dependencies (if not already available):
@@ -19,5 +20,24 @@ This project extracts transaction data from emails and stores it in a local SQLi
    pip install -r requirements.txt
    ```
 
-3. Run the extraction scripts located in the `Application` folder.
+3. Install Node dependencies for the frontend and backend:
+   ```bash
+   cd Client && npm install       # React client
+   cd ../Server && npm install    # Express server
+   ```
+
+4. Build and run the React client (from the `Client` directory):
+   ```bash
+   npm start
+   ```
+
+5. Start the Express server (from the `Server` directory):
+   ```bash
+   npm start
+   ```
+   The server uses the `PORT` environment variable if set, otherwise defaults to `5000`.
+
+6. Run the extraction scripts located in the `Application` folder.
+
+SQLite is the default database. The file is stored at `Database/transactions.db`.
 

--- a/Server/Server.js
+++ b/Server/Server.js
@@ -4,7 +4,8 @@ const cors = require('cors');
 const path = require('path');
 
 const app = express();
-const port = 5000;
+// Allow overriding the port via environment variable
+const port = process.env.PORT || 5000;
 
 app.use(cors());
 app.use(express.json()); // ✅ Allow JSON request body parsing

--- a/Server/package.json
+++ b/Server/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
+    "start": "node Server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- document node install steps, client build instructions, server start
- support overriding port from environment
- add start script to Express server

## Testing
- `npm test` in `Server` *(fails: Error: no test specified)*
- `npm test --silent` in `Client` *(failed to run react-scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68698244332c832b91b9b3b7f421c210