### PR TITLE
Ignore node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ credentials.yml
 
 # Ignore Python cache
 __pycache__/
+
+# Ignore Node dependencies
+node_modules/

--- a/README.md
+++ b/README.md
@@ -21,3 +21,9 @@ This project extracts transaction data from emails and stores it in a local SQLi
 
 3. Run the extraction scripts located in the `Application` folder.
 
+## Development Notes
+
+Some folders contain Node-based tools. After cloning the repo, run `npm install`
+within those folders to generate `node_modules`. These dependencies are large
+and are ignored by Git. Please avoid committing `node_modules/` directories.
+


### PR DESCRIPTION
## Summary
- ignore Node dependencies globally
- document that node_modules should not be committed

## Testing
- `npm test --prefix Client` *(fails: react-scripts not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68698241494c832b8b83b2b2d872b5df