### PR TITLE
Add email processing endpoints

### DIFF
--- a/Application/api_scripts/extract_emails.py
+++ b/Application/api_scripts/extract_emails.py
@@ -1,0 +1,28 @@
+import sys
+import os
+import json
+
+# Ensure modules in the parent directory (Application) are importable
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from extracteur import fetch_emails
+from traitement import extract_transaction_data
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(json.dumps({'error': 'start_date and end_date required'}))
+        return
+    start_date = sys.argv[1]
+    end_date = sys.argv[2]
+
+    emails = fetch_emails(start_date, end_date)
+    results = []
+    for email in emails:
+        trans = extract_transaction_data(email, email.get('sender'), email.get('subject'), email.get('email_datetime'))
+        results.append({'email': email, 'transaction': trans})
+    print(json.dumps(results))
+
+
+if __name__ == '__main__':
+    main()

--- a/Application/api_scripts/process_queue.py
+++ b/Application/api_scripts/process_queue.py
@@ -1,0 +1,32 @@
+import sys
+import os
+import json
+
+# Ensure Application modules are importable
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from traitement import extract_transaction_data
+from Database.Insert import insert_transaction
+
+
+def main():
+    raw = sys.stdin.read()
+    if not raw:
+        print(json.dumps({'error': 'no data'}))
+        return
+    try:
+        emails = json.loads(raw)
+    except json.JSONDecodeError:
+        print(json.dumps({'error': 'invalid json'}))
+        return
+
+    results = []
+    for email in emails:
+        trans = extract_transaction_data(email, email.get('sender'), email.get('subject'), email.get('email_datetime'))
+        insert_transaction(trans)
+        results.append(trans)
+    print(json.dumps(results))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- create `extract_emails.py` and `process_queue.py` for API use
- add Node endpoints `/api/extract-emails`, `/api/process-queue`, and `/api/transactions/:id/email`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `python3 Application/api_scripts/extract_emails.py 01-Jan-2020 02-Jan-2020` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686b0a31d92c832b86d8aa3365fe7577