### PR TITLE
Add email viewer modal

### DIFF
--- a/client/src/components/Sections/TransactionTable.jsx
+++ b/client/src/components/Sections/TransactionTable.jsx
@@ -1,6 +1,7 @@
 // src/components/Sections/TransactionTable.jsx
-import React from 'react';
+import React, { useState } from 'react';
 import TransactionActionsMenu from '../common/TransactionActionsMenu';
+import EmailViewerModal from '../common/EmailViewerModal';
 import { useTranslation } from 'react-i18next';
 
 // We need to create a wrapper component to fix the dropdown positioning
@@ -27,7 +28,8 @@ const EditableTransactionRow = ({
   removeTag,
   filters,
   onOpenTagModal,
-  onDeleteTransaction
+  onDeleteTransaction,
+  onViewEmail
 }) => {
   const isEditing = (field) => editingTransaction === `${transaction.id}-${field}`;
   
@@ -220,6 +222,7 @@ const EditableTransactionRow = ({
           onOpenTagModal={onOpenTagModal}
           onDeleteTransaction={onDeleteTransaction}
           removeTag={removeTag}
+          onViewEmail={onViewEmail}
         />
       </td>
     </tr>
@@ -253,7 +256,21 @@ const TransactionTable = ({
   const { t } = useTranslation();
   const totalPages = Math.ceil(filteredTransactions.length / itemsPerPage);
 
+  const [showEmailModal, setShowEmailModal] = useState(false);
+  const [emailModalTransaction, setEmailModalTransaction] = useState(null);
+
+  const handleViewEmail = (txn) => {
+    setEmailModalTransaction(txn);
+    setShowEmailModal(true);
+  };
+
+  const handleCloseEmailModal = () => {
+    setShowEmailModal(false);
+    setEmailModalTransaction(null);
+  };
+
   return (
+    <>
     <div className="bg-white rounded-3xl shadow-xl border overflow-hidden">
       {/* Header */}
       <div className="p-8 border-b bg-gray-50">
@@ -337,6 +354,7 @@ const TransactionTable = ({
                 onOpenTagModal={onOpenTagModal}
                 removeTag={removeTag}
                 onDeleteTransaction={onDeleteTransaction}
+                onViewEmail={handleViewEmail}
               />
             ))}
           </tbody>
@@ -367,6 +385,12 @@ const TransactionTable = ({
         </div>
       </div>
     </div>
+    <EmailViewerModal
+      isOpen={showEmailModal}
+      onClose={handleCloseEmailModal}
+      transaction={emailModalTransaction}
+    />
+    </>
   );
 };
 

--- a/client/src/components/common/EmailViewerModal.jsx
+++ b/client/src/components/common/EmailViewerModal.jsx
@@ -1,0 +1,62 @@
+import React, { useState, useEffect } from 'react';
+import { X } from 'lucide-react';
+
+const EmailViewerModal = ({ isOpen, onClose, transaction }) => {
+  const [emailHtml, setEmailHtml] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const fetchEmail = async () => {
+      if (isOpen && transaction) {
+        try {
+          setLoading(true);
+          const res = await fetch(`/api/transactions/${transaction.id}/email`);
+          if (!res.ok) throw new Error('Failed to fetch email');
+          const data = await res.json();
+          setEmailHtml(data.full_email || '');
+        } catch (err) {
+          console.error('Failed to fetch email:', err);
+          setEmailHtml('<p class="text-red-600">Failed to load email.</p>');
+        } finally {
+          setLoading(false);
+        }
+      }
+    };
+    fetchEmail();
+  }, [isOpen, transaction]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-2xl shadow-2xl w-full max-w-3xl max-h-[90vh] overflow-hidden flex flex-col">
+        <div className="p-6 border-b bg-gray-50 flex justify-between items-center">
+          <h2 className="text-xl font-semibold text-gray-900">Original Email</h2>
+          <button
+            onClick={onClose}
+            className="p-2 hover:bg-gray-200 rounded-full transition-colors duration-200"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+        <div className="p-6 overflow-auto flex-1">
+          {loading ? (
+            <div className="text-center text-sm text-gray-500">Loading...</div>
+          ) : (
+            <div dangerouslySetInnerHTML={{ __html: emailHtml }} />
+          )}
+        </div>
+        <div className="p-6 border-t bg-gray-50 flex justify-end">
+          <button
+            onClick={onClose}
+            className="px-6 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-100 transition-colors duration-200"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EmailViewerModal;

--- a/client/src/components/common/TransactionActionsMenu.jsx
+++ b/client/src/components/common/TransactionActionsMenu.jsx
@@ -1,13 +1,14 @@
 // src/components/common/TransactionActionsMenu.jsx
 import React, { useState, useRef, useEffect } from 'react';
-import { MoreVertical, Tag, Trash2, DollarSign, FileText, Folder } from 'lucide-react';
+import { MoreVertical, Tag, Trash2, DollarSign, FileText, Folder, Mail } from 'lucide-react';
 
-const TransactionActionsMenu = ({ 
-  transaction, 
-  onStartEdit, 
-  onOpenTagModal, 
+const TransactionActionsMenu = ({
+  transaction,
+  onStartEdit,
+  onOpenTagModal,
   onDeleteTransaction,
-  removeTag 
+  onViewEmail,
+  removeTag
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef(null);
@@ -39,6 +40,9 @@ const TransactionActionsMenu = ({
         break;
       case 'edit-tags':
         onOpenTagModal(transaction);
+        break;
+      case 'view-email':
+        if (onViewEmail) onViewEmail(transaction);
         break;
       case 'delete':
         if (window.confirm('Are you sure you want to delete this transaction?')) {
@@ -101,6 +105,14 @@ const TransactionActionsMenu = ({
           >
             <Tag className="w-4 h-4 text-gray-600" />
             <span className="font-medium text-gray-900">Manage Tags</span>
+          </button>
+
+          <button
+            onClick={() => handleAction('view-email')}
+            className="w-full px-4 py-3 text-left hover:bg-gray-50 flex items-center gap-3 text-sm transition-colors duration-200"
+          >
+            <Mail className="w-4 h-4 text-gray-600" />
+            <span className="font-medium text-gray-900">View Original Email</span>
           </button>
 
           {/* Divider */}


### PR DESCRIPTION
## Summary
- include EmailViewerModal to show original transaction emails
- add view email option to transaction action menu
- open modal from TransactionTable and fetch email HTML

## Testing
- `npm test --silent --maxWorkers=2` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b0ffd2b3c832bba27f171d55bd38c