### PR TITLE
Add email extraction translations and nav

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import TransactionDashboard from './components/TransactionDashboard';
 import EmailExtractionPage from './components/EmailExtractionPage';
 import './index.css';
@@ -7,10 +7,6 @@ import './index.css';
 function App() {
   return (
     <Router>
-      <nav className="bg-gray-800 text-white p-4 flex gap-4">
-        <Link to="/" className="hover:underline">Dashboard</Link>
-        <Link to="/email-extraction" className="hover:underline">Email Extraction</Link>
-      </nav>
       <Routes>
         <Route path="/" element={<TransactionDashboard />} />
         <Route path="/email-extraction" element={<EmailExtractionPage />} />

--- a/client/src/components/EmailExtractionPage.jsx
+++ b/client/src/components/EmailExtractionPage.jsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
 import Header from './ui/Header';
+import { useTranslation } from 'react-i18next';
 import { emailService } from '../Services/emailService';
 import { transactionService } from '../Services/transactionService';
 
 const EmailExtractionPage = () => {
+  const { t } = useTranslation();
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
   const [queue, setQueue] = useState([]); // {email, transaction}
@@ -88,7 +90,7 @@ const EmailExtractionPage = () => {
       <div className="bg-white p-8 rounded-3xl shadow-xl border mb-8">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           <div>
-            <label className="block text-sm font-medium mb-2">Start Date</label>
+            <label className="block text-sm font-medium mb-2">{t('emailExtraction.startDate')}</label>
             <input
               type="date"
               value={startDate}
@@ -97,7 +99,7 @@ const EmailExtractionPage = () => {
             />
           </div>
           <div>
-            <label className="block text-sm font-medium mb-2">End Date</label>
+            <label className="block text-sm font-medium mb-2">{t('emailExtraction.endDate')}</label>
             <input
               type="date"
               value={endDate}
@@ -110,7 +112,7 @@ const EmailExtractionPage = () => {
               onClick={loadEmails}
               className="w-full bg-blue-500 text-white px-4 py-3 rounded-xl hover:bg-blue-600"
             >
-              {loading ? 'Extracting...' : 'Extract Emails'}
+              {loading ? t('emailExtraction.extracting') : t('emailExtraction.extract')}
             </button>
           </div>
         </div>
@@ -121,13 +123,13 @@ const EmailExtractionPage = () => {
           <div className="flex justify-between mb-4">
             <div className="space-x-2">
               <button onClick={selectAll} className="px-3 py-1 border rounded-xl text-sm">
-                Select All
+                {t('queue.selectAll')}
               </button>
               <button onClick={clearSelection} className="px-3 py-1 border rounded-xl text-sm">
-                Clear
+                {t('queue.clear')}
               </button>
               <button onClick={removeSelected} className="px-3 py-1 border rounded-xl text-sm">
-                Remove
+                {t('queue.remove')}
               </button>
             </div>
             <div className="space-x-2">
@@ -135,13 +137,13 @@ const EmailExtractionPage = () => {
                 onClick={processSelected}
                 className="px-4 py-2 bg-green-600 text-white rounded-xl hover:bg-green-700"
               >
-                Process Selected
+                {t('queue.processSelected')}
               </button>
               <button
                 onClick={processAll}
                 className="px-4 py-2 bg-green-700 text-white rounded-xl hover:bg-green-800"
               >
-                Process All
+                {t('queue.processAll')}
               </button>
             </div>
           </div>
@@ -155,10 +157,10 @@ const EmailExtractionPage = () => {
                     onChange={() => (allSelected ? clearSelection() : selectAll())}
                   />
                 </th>
-                <th className="px-6 py-3">Date</th>
-                <th className="px-6 py-3">Amount</th>
-                <th className="px-6 py-3">Description</th>
-                <th className="px-6 py-3">Duplicate</th>
+                <th className="px-6 py-3">{t('queue.table.date')}</th>
+                <th className="px-6 py-3">{t('queue.table.amount')}</th>
+                <th className="px-6 py-3">{t('queue.table.description')}</th>
+                <th className="px-6 py-3">{t('queue.table.duplicate')}</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200">
@@ -175,14 +177,16 @@ const EmailExtractionPage = () => {
                   <td className="px-6 py-4">{item.transaction.amount}</td>
                   <td className="px-6 py-4">{item.transaction.description}</td>
                   <td className="px-6 py-4 text-red-600">
-                    {item.transaction.duplicate ? 'Yes' : 'No'}
+                    {item.transaction.duplicate ? t('queue.table.duplicateYes') : t('queue.table.duplicateNo')}
                   </td>
                 </tr>
               ))}
             </tbody>
           </table>
           {processing && (
-            <p className="mt-4 text-sm text-gray-600">Processing {progress} of {queue.length}...</p>
+            <p className="mt-4 text-sm text-gray-600">
+              {t('queue.processing', { current: progress, total: queue.length })}
+            </p>
           )}
         </div>
       )}

--- a/client/src/components/ui/Header.jsx
+++ b/client/src/components/ui/Header.jsx
@@ -1,15 +1,21 @@
-
-// src/components/ui/Header.jsx (Create this file)
 import React from 'react';
 import { useTranslation } from 'react-i18next';
- 
-const Header = ({ onSettingsToggle, showSettings }) => {
+import { Link, useLocation } from 'react-router-dom';
+
+const Header = () => {
   const { t } = useTranslation();
+  const location = useLocation();
+
+  const linkClasses = (path) =>
+    `px-3 py-2 rounded-xl ${location.pathname === path ? 'bg-blue-600 text-white' : 'text-blue-600 hover:underline'}`;
 
   return (
     <div className="flex justify-between items-center mb-8">
       <h1 className="text-4xl font-bold text-gray-900">{t('header.title')}</h1>
-
+      <nav className="space-x-2">
+        <Link to="/" className={linkClasses('/')}>{t('navigation.dashboard')}</Link>
+        <Link to="/email-extraction" className={linkClasses('/email-extraction')}>{t('navigation.emailExtraction')}</Link>
+      </nav>
     </div>
   );
 };

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -42,4 +42,22 @@
   "settings.tabs.tags": "Tags",
   "settings.tabs.mappings": "Mappings",
   "settings.tabs.transactions": "Transactions"
+  ,"navigation.dashboard": "Dashboard"
+  ,"navigation.emailExtraction": "Email Extraction"
+  ,"emailExtraction.startDate": "Start Date"
+  ,"emailExtraction.endDate": "End Date"
+  ,"emailExtraction.extract": "Extract Emails"
+  ,"emailExtraction.extracting": "Extracting..."
+  ,"queue.selectAll": "Select All"
+  ,"queue.clear": "Clear"
+  ,"queue.remove": "Remove"
+  ,"queue.processSelected": "Process Selected"
+  ,"queue.processAll": "Process All"
+  ,"queue.table.date": "Date"
+  ,"queue.table.amount": "Amount"
+  ,"queue.table.description": "Description"
+  ,"queue.table.duplicate": "Duplicate"
+  ,"queue.table.duplicateYes": "Yes"
+  ,"queue.table.duplicateNo": "No"
+  ,"queue.processing": "Processing {{current}} of {{total}}..."
 }

--- a/client/src/locales/fr/translation.json
+++ b/client/src/locales/fr/translation.json
@@ -42,4 +42,22 @@
   "settings.tabs.tags": "Tags",
   "settings.tabs.mappings": "Correspondances",
   "settings.tabs.transactions": "Transactions"
+  ,"navigation.dashboard": "Tableau de bord"
+  ,"navigation.emailExtraction": "Extraction d'emails"
+  ,"emailExtraction.startDate": "Date de début"
+  ,"emailExtraction.endDate": "Date de fin"
+  ,"emailExtraction.extract": "Extraire les emails"
+  ,"emailExtraction.extracting": "Extraction..."
+  ,"queue.selectAll": "Tout sélectionner"
+  ,"queue.clear": "Effacer"
+  ,"queue.remove": "Supprimer"
+  ,"queue.processSelected": "Traiter la sélection"
+  ,"queue.processAll": "Tout traiter"
+  ,"queue.table.date": "Date"
+  ,"queue.table.amount": "Montant"
+  ,"queue.table.description": "Description"
+  ,"queue.table.duplicate": "Dupliquer"
+  ,"queue.table.duplicateYes": "Oui"
+  ,"queue.table.duplicateNo": "Non"
+  ,"queue.processing": "Traitement de {{current}} sur {{total}}..."
 }


### PR DESCRIPTION
## Summary
- add header navigation with links to dashboard and email extraction pages
- internationalize email extraction page strings
- localize queue action labels
- update English and French translation files
- remove legacy nav from App

## Testing
- `npm test --silent --maxWorkers=2` *(fails: react-scripts not found)*
- `npm run build --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b189b482c832b90614a51a984b56c