### PR TITLE
Add row removal to email extraction queue

### DIFF
--- a/client/src/components/EmailExtractionPage.jsx
+++ b/client/src/components/EmailExtractionPage.jsx
@@ -49,6 +49,15 @@ const EmailExtractionPage = () => {
     setSelectedIds([]);
   };
 
+  const removeFromQueue = (idxToRemove) => {
+    setQueue((prev) => prev.filter((_, idx) => idx !== idxToRemove));
+    setSelectedIds((prev) =>
+      prev
+        .filter((id) => id !== idxToRemove)
+        .map((id) => (id > idxToRemove ? id - 1 : id))
+    );
+  };
+
   const clearQueue = () => {
     setQueue([]);
     setSelectedIds([]);
@@ -172,6 +181,7 @@ const EmailExtractionPage = () => {
                 <th className="px-6 py-3">{t('queue.table.amount')}</th>
                 <th className="px-6 py-3">{t('queue.table.description')}</th>
                 <th className="px-6 py-3">{t('queue.table.duplicate')}</th>
+                <th className="px-6 py-3">{t('queue.table.remove')}</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200">
@@ -192,6 +202,14 @@ const EmailExtractionPage = () => {
                   <td className="px-6 py-4">{item.transaction.description}</td>
                   <td className="px-6 py-4 text-red-600">
                     {item.transaction.duplicate ? t('queue.table.duplicateYes') : t('queue.table.duplicateNo')}
+                  </td>
+                  <td className="px-6 py-4">
+                    <button
+                      onClick={() => removeFromQueue(idx)}
+                      className="text-red-600 hover:text-red-800"
+                    >
+                      {t('queue.table.remove')}
+                    </button>
                   </td>
                 </tr>
               ))}

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -59,5 +59,6 @@
   ,"queue.table.duplicate": "Duplicate"
   ,"queue.table.duplicateYes": "Yes"
   ,"queue.table.duplicateNo": "No"
+  ,"queue.table.remove": "Remove"
   ,"queue.processing": "Processing {{current}} of {{total}}..."
 }

--- a/client/src/locales/fr/translation.json
+++ b/client/src/locales/fr/translation.json
@@ -59,5 +59,6 @@
   ,"queue.table.duplicate": "Dupliquer"
   ,"queue.table.duplicateYes": "Oui"
   ,"queue.table.duplicateNo": "Non"
+  ,"queue.table.remove": "Supprimer"
   ,"queue.processing": "Traitement de {{current}} sur {{total}}..."
 }


### PR DESCRIPTION
## Summary
- add button to remove single emails from the extraction queue
- update locale files with text for the new remove button

## Testing
- `npm test --silent -- -w 1`

------
https://chatgpt.com/codex/tasks/task_e_686b23f6b0b4832b9cade5f04e2d4432