### PR TITLE
Add bank column and duplicate icon

### DIFF
--- a/client/src/components/EmailExtractionPage.jsx
+++ b/client/src/components/EmailExtractionPage.jsx
@@ -3,6 +3,7 @@ import Header from './ui/Header';
 import { useTranslation } from 'react-i18next';
 import { emailService } from '../Services/emailService';
 import { useTransactions } from '../hooks/useTransactions';
+import { AlertTriangle } from 'lucide-react';
 
 const EmailExtractionPage = () => {
   const { t } = useTranslation();
@@ -180,6 +181,7 @@ const EmailExtractionPage = () => {
                 <th className="px-6 py-3">{t('queue.table.date')}</th>
                 <th className="px-6 py-3">{t('queue.table.amount')}</th>
                 <th className="px-6 py-3">{t('queue.table.description')}</th>
+                <th className="px-6 py-3">{t('queue.table.bank')}</th>
                 <th className="px-6 py-3">{t('queue.table.duplicate')}</th>
                 <th className="px-6 py-3">{t('queue.table.remove')}</th>
               </tr>
@@ -200,7 +202,9 @@ const EmailExtractionPage = () => {
                   <td className="px-6 py-4">{item.transaction.date}</td>
                   <td className="px-6 py-4">{item.transaction.amount}</td>
                   <td className="px-6 py-4">{item.transaction.description}</td>
-                  <td className="px-6 py-4 text-red-600">
+                  <td className="px-6 py-4">{item.transaction.bank}</td>
+                  <td className="px-6 py-4 text-red-600 flex items-center gap-1">
+                    {item.transaction.duplicate && <AlertTriangle className="w-4 h-4" />}
                     {item.transaction.duplicate ? t('queue.table.duplicateYes') : t('queue.table.duplicateNo')}
                   </td>
                   <td className="px-6 py-4">

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -56,6 +56,7 @@
   ,"queue.table.date": "Date"
   ,"queue.table.amount": "Amount"
   ,"queue.table.description": "Description"
+  ,"queue.table.bank": "Bank"
   ,"queue.table.duplicate": "Duplicate"
   ,"queue.table.duplicateYes": "Yes"
   ,"queue.table.duplicateNo": "No"

--- a/client/src/locales/fr/translation.json
+++ b/client/src/locales/fr/translation.json
@@ -56,6 +56,7 @@
   ,"queue.table.date": "Date"
   ,"queue.table.amount": "Montant"
   ,"queue.table.description": "Description"
+  ,"queue.table.bank": "Banque"
   ,"queue.table.duplicate": "Dupliquer"
   ,"queue.table.duplicateYes": "Oui"
   ,"queue.table.duplicateNo": "Non"


### PR DESCRIPTION
## Summary
- extend email extraction table to show the transaction bank
- show an AlertTriangle icon next to duplicate rows
- localize new bank column heading

## Testing
- `npm test --prefix client -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_686b26c5eb0c832b9924c9a2d6bb85f3