### PR TITLE
Add TypeScript dev dependency

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -25,7 +25,8 @@
       "devDependencies": {
         "autoprefixer": "^10.4.21",
         "postcss": "^8.5.4",
-        "tailwindcss": "^3.4.0"
+        "tailwindcss": "^3.4.0",
+        "typescript": "4.9.5"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -16830,6 +16831,20 @@
       "license": "MIT",
       "dependencies": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/client/package.json
+++ b/client/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.4",
-    "tailwindcss": "^3.4.0"
+    "tailwindcss": "^3.4.0",
+    "typescript": "4.9.5"
   }
 }


### PR DESCRIPTION
## Summary
- include `typescript` 4.9.5 in the client dev dependencies
- regenerate `package-lock.json` by running `npm install` (used `--legacy-peer-deps` due to peer dependency conflicts)

## Testing
- `npm install --legacy-peer-deps`

------
https://chatgpt.com/codex/tasks/task_e_686b2f4392b0832b9ccbc50bbf89b3ac