### PR TITLE
Fix date formatting for email extraction

### DIFF
--- a/Server/Server.js
+++ b/Server/Server.js
@@ -380,8 +380,18 @@ app.post('/api/extract-emails', (req, res) => {
         return res.status(400).json({ error: 'startDate and endDate required' });
     }
 
+    // Convert YYYY-MM-DD to DD-Mon-YYYY for the Python script
+    function formatDate(iso) {
+        const [y, m, d] = iso.split('-');
+        const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+        return `${d}-${months[parseInt(m, 10) - 1]}-${y}`;
+    }
+
+    const formattedStart = formatDate(startDate);
+    const formattedEnd = formatDate(endDate);
+
     const script = path.join(__dirname, '../Application/api_scripts/extract_emails.py');
-    const py = spawn('python3', [script, startDate, endDate]);
+    const py = spawn('python3', [script, formattedStart, formattedEnd]);
 
     let output = '';
     let errOutput = '';


### PR DESCRIPTION
## Summary
- format dates for the `/api/extract-emails` endpoint

## Testing
- `npm start` *(fails: invalid ELF header while loading sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_686b34f56c7c832ba16b4636fe016feb