### PR TITLE
Clarify Python usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project extracts transaction data from emails and stores it in a local SQLite database.
 
+Make sure **Python 3** is installed and accessible from your command line. Some platforms expose the interpreter as `python3` instead of `python`. You can set a `PYTHON_CMD` environment variable pointing to the correct command if needed.
+
 ## Setup
 
 1. **Provide email credentials** used by the extraction scripts.
@@ -14,11 +16,16 @@ This project extracts transaction data from emails and stores it in a local SQLi
    EMAIL_USER=your_email@example.com
    EMAIL_PASS=your_app_password
    ```
-2. Install Python dependencies (if not already available):
+2. Install Python dependencies (if not already available) using `pip`:
    ```bash
    pip install -r requirements.txt
+   # use `pip3` if your system separates Python 2 and 3
    ```
-3. Run the extraction scripts located in the `Application` folder.
+3. Run the extraction scripts located in the `Application` folder using Python 3:
+   ```bash
+   ${PYTHON_CMD:-python} Application/main.py
+   ```
+   Replace `main.py` with whichever script you want to execute. Set `PYTHON_CMD` if `python` does not point to Python 3 on your system.
 
 
 ## Running the React client and Node server


### PR DESCRIPTION
## Summary
- add Python 3 requirement note and mention `PYTHON_CMD`
- document using pip/pip3 to install requirements
- show example of running scripts with `PYTHON_CMD`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686b47cabc54832bbb00acfbca1a53c2