### PR TITLE
Improve API error handling

### DIFF
--- a/client/src/Services/api.js
+++ b/client/src/Services/api.js
@@ -1,13 +1,27 @@
 // src/services/api.js - Base API configuration
 const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000';
 
+const handleResponse = async (response) => {
+  let data = {};
+  try {
+    const text = await response.text();
+    data = text ? JSON.parse(text) : {};
+  } catch (e) {
+    data = {};
+  }
+
+  if (!response.ok) {
+    const message = data.error || `HTTP error! status: ${response.status}`;
+    throw new Error(message);
+  }
+
+  return data;
+};
+
 export const apiClient = {
   get: async (endpoint) => {
     const response = await fetch(`${API_BASE_URL}${endpoint}`);
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-    return response.json();
+    return handleResponse(response);
   },
 
   post: async (endpoint, data) => {
@@ -18,10 +32,7 @@ export const apiClient = {
       },
       body: JSON.stringify(data),
     });
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-    return response.json();
+    return handleResponse(response);
   },
 
   put: async (endpoint, data) => {
@@ -32,10 +43,7 @@ export const apiClient = {
       },
       body: JSON.stringify(data),
     });
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-    return response.json();
+    return handleResponse(response);
   },
 
   delete: async (endpoint, data = null) => {
@@ -51,10 +59,7 @@ export const apiClient = {
     }
 
     const response = await fetch(`${API_BASE_URL}${endpoint}`, options);
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-    return response.json();
+    return handleResponse(response);
   },
 };
 

--- a/client/src/components/EmailExtractionPage.jsx
+++ b/client/src/components/EmailExtractionPage.jsx
@@ -26,6 +26,7 @@ const EmailExtractionPage = () => {
       setSelectedIds(data.map((_, idx) => idx));
     } catch (err) {
       console.error(err);
+      alert(err.message || 'Failed to extract emails');
     } finally {
       setLoading(false);
     }
@@ -76,6 +77,7 @@ const EmailExtractionPage = () => {
       await refreshTransactions();
     } catch (err) {
       console.error(err);
+      alert(err.message || 'Failed to process emails');
     } finally {
       setProcessing(false);
     }


### PR DESCRIPTION
## Summary
- capture server error messages by parsing all responses in `api.js`
- alert error messages on Email Extraction page

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_686b47c9068c832baaf7c42246af8198