### PR TITLE
Increase server payload limit

### DIFF
--- a/Server/Server.js
+++ b/Server/Server.js
@@ -12,7 +12,8 @@ const app = express();
 const port = process.env.PORT || 5000;
 
 app.use(cors());
-app.use(express.json()); // ✅ Allow JSON request body parsing
+// Increase JSON payload limit to handle larger request bodies
+app.use(express.json({ limit: '10mb' })); // ✅ Allow JSON request body parsing
 
 // ✅ Construct absolute path to transactions.db in Database folder
 const dbPath = path.join(__dirname, '../Database/transactions.db');


### PR DESCRIPTION
## Summary
- bump JSON body size limit for Express

## Testing
- `npm start` *(fails: invalid ELF header for sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_686b52b14804832b9b0c435e21251464