### PR TITLE
Fix process queue import path

### DIFF
--- a/Application/api_scripts/process_queue.py
+++ b/Application/api_scripts/process_queue.py
@@ -2,8 +2,10 @@ import sys
 import os
 import json
 
-# Ensure Application modules are importable
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+# Ensure Application and project root modules are importable
+current_dir = os.path.dirname(__file__)
+sys.path.append(os.path.abspath(os.path.join(current_dir, '..')))
+sys.path.append(os.path.abspath(os.path.join(current_dir, '..', '..')))
 
 from traitement import extract_transaction_data
 from Database.Insert import insert_transaction


### PR DESCRIPTION
## Summary
- ensure process_queue.py can import Database modules

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm test --prefix Server` *(fails: no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_686b3746649c832b8152f375fa45314b