### PR TITLE
Store HTML email content

### DIFF
--- a/Application/traitement.py
+++ b/Application/traitement.py
@@ -123,7 +123,7 @@ def extract_transaction_data(
         "date": formatted_date.split(" ")[0] if formatted_date else None,
         "time": formatted_date.split(" ")[1] if formatted_date else None,
         "bank": bank_name,
-        "full_email": email_text,
+        "full_email": html if html else email_text,
     }
 
     dup = False


### PR DESCRIPTION
## Summary
- store HTML from emails in the DB rather than the extracted text so the viewer modal can display the message as originally sent

## Testing
- `npm test --prefix client --silent -- -w 0` *(fails: react-scripts not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b344dbbfc832ba5f440ba9947b184