### PR TITLE
Enable transaction deletion in dashboard

### DIFF
--- a/Server/Server.js
+++ b/Server/Server.js
@@ -512,6 +512,29 @@ app.put('/api/transactions/:id/description', (req, res) => {
     });
 });
 
+// ✅ Delete a transaction
+app.delete('/api/transactions/:id', (req, res) => {
+    const { id } = req.params;
+
+    // Remove any tag links first
+    db.run('DELETE FROM transaction_tags WHERE transaction_id = ?', [id], function (err) {
+        if (err) {
+            return res.status(500).json({ error: err.message });
+        }
+
+        // Now delete the transaction itself
+        db.run('DELETE FROM transactions WHERE id = ?', [id], function (err2) {
+            if (err2) {
+                return res.status(500).json({ error: err2.message });
+            }
+            if (this.changes === 0) {
+                return res.status(404).json({ error: "Transaction not found" });
+            }
+            res.json({ message: `✅ Transaction ID ${id} deleted` });
+        });
+    });
+});
+
 
 
 // Add these endpoints to your server.js

--- a/client/src/Services/transactionService.js
+++ b/client/src/Services/transactionService.js
@@ -21,8 +21,21 @@ export const transactionService = {
     apiClient.post(`/api/transactions/${transactionId}/tags`, { tag }),
 
   // Remove tag from transaction
-  removeTag: (transactionId, tag) => 
+  removeTag: (transactionId, tag) =>
     apiClient.delete(`/api/transactions/${transactionId}/tags`, { tag }),
+
+  // Delete a transaction
+  delete: async (id) => {
+    console.log('🔄 Deleting transaction:', id);
+    try {
+      const result = await apiClient.delete(`/api/transactions/${id}`);
+      console.log('✅ Transaction deleted successfully');
+      return result;
+    } catch (error) {
+      console.error('❌ Failed to delete transaction:', error);
+      throw error;
+    }
+  },
 
   // Update transaction category
   updateCategory: (id, category) => 

--- a/client/src/components/TransactionDashboard.jsx
+++ b/client/src/components/TransactionDashboard.jsx
@@ -22,15 +22,16 @@ const TransactionDashboard = () => {
 
 
 // Find this line and update it to include the new methods:
-const { 
-  transactions: realTransactions, 
-  loading, 
+const {
+  transactions: realTransactions,
+  loading,
   error,
   addTag,
   removeTag,
   updateCategory,
   updateAmount,        // ← ADD THIS
-  updateDescription    // ← ADD THIS
+  updateDescription,   // ← ADD THIS
+  deleteTransaction
 } = useTransactions();
 
 // Add these hooks after your useTransactions hook:
@@ -380,10 +381,14 @@ const handleCancelEdit = () => {
 // Add this handler after your other handlers:
 const handleDeleteTransaction = async (transactionId) => {
   try {
-    // You'll need to implement this API endpoint
     console.log('🗑️ Deleting transaction:', transactionId);
-    // For now, just log - you can implement the actual deletion later
-    alert('Delete functionality coming soon!');
+    await deleteTransaction(transactionId);
+
+    if (!useRealData) {
+      setTransactions(prev => prev.filter(t => t.id !== transactionId));
+    }
+
+    alert('Transaction deleted successfully!');
   } catch (error) {
     console.error('Failed to delete transaction:', error);
     alert('Failed to delete transaction. Please try again.');

--- a/client/src/hooks/useTransactions.js
+++ b/client/src/hooks/useTransactions.js
@@ -96,6 +96,17 @@ const updateDescription = async (id, description) => {
   }
 };
 
+const deleteTransaction = async (id) => {
+  try {
+    await transactionService.delete(id);
+    await loadTransactions(); // Reload to get updated data
+  } catch (err) {
+    console.error('Error deleting transaction:', err);
+    setError(err.message);
+    throw err;
+  }
+};
+
 // Update your return statement to include these new methods:
 return {
   transactions,
@@ -105,8 +116,9 @@ return {
   addTag,
   removeTag,
   updateCategory,
-  updateAmount,        
-  updateDescription,   
+  updateAmount,
+  updateDescription,
+  deleteTransaction,
 };
 
 


### PR DESCRIPTION
## Summary
- add backend API route for deleting transactions
- expose `delete` method in transaction service
- support deleting transactions in `useTransactions` hook
- wire up deletion handler in `TransactionDashboard` UI

## Testing
- `npm test` *(fails: react-scripts not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bf4926c90832ba526ad6a1377c2c2