### PR TITLE
Add DB column check and upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,12 @@ You can place this variable in a `.env` file inside the `client` folder.
 The Node server uses the optional `PORT` environment variable and reads the SQLite
 `transactions.db` from the `Database` directory.
 
+## Database schema upgrades
+If you update the project and new columns are added (for example the
+`category` field), run the database creation script again:
+
+```bash
+python Database/Database.py
+```
+This will alter the existing database tables to include any missing columns.
+


### PR DESCRIPTION
## Summary
- add helper function to ensure required columns exist
- call helper from `create_database`
- document running `Database.py` after pulling updates

## Testing
- `python -m py_compile Database/Database.py`

------
https://chatgpt.com/codex/tasks/task_e_686c6171e4c0832b8a6623a84293cd15