### PR TITLE
Update test docs & add install helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The web interface lives in the `client` folder while the API server resides in `
    # or install TypeScript 4.9 manually if you prefer
    npm install typescript@4.9 --save-dev
    ```
+   Run `npm install` within `client/` before `npm test`.
 2. **Server**
    ```bash
    cd Server

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "expensetracker-root",
+  "private": true,
+  "scripts": {
+    "postinstall": "npm --prefix client install --legacy-peer-deps"
+  }
+}


### PR DESCRIPTION
## Summary
- mention running `npm install` in the `client` folder before running tests
- add a root `package.json` with a postinstall hook to install client deps automatically

## Testing
- `npm --prefix client install --legacy-peer-deps`
- `npm --prefix client test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_686c617ef0f8832bacb35b62a1c853bf