### PR TITLE
Handle multiple regex patterns

### DIFF
--- a/Application/tests/test_traitement.py
+++ b/Application/tests/test_traitement.py
@@ -35,3 +35,18 @@ def test_unknown_bank(monkeypatch):
     result = traitement.extract_transaction_data(data)
     assert result["bank"] == "Unknown"
     assert result["amount"] is None
+
+
+def test_neo_credit_multiple_regex(monkeypatch):
+    monkeypatch.setattr(traitement, "is_duplicate", lambda amount, date: False)
+    email = {
+        "full_email_html": "<p>You earned cashback on your purchase of $12.34 at Starbucks</p>",
+        "sender": "info@neofinancial.com",
+        "subject": "Your purchase at Starbucks",
+        "email_datetime": "Mon, 01 Jan 2024 12:00:00 +0000",
+        "bank_config": "neo_credit",
+    }
+    result = traitement.extract_transaction_data(email)
+    assert result["bank"] == "neo_credit"
+    assert result["amount"] == "12.34"
+    assert result["description"] == "Starbucks"

--- a/Application/traitement.py
+++ b/Application/traitement.py
@@ -104,8 +104,23 @@ def extract_transaction_data(
     if bank_name != "Unknown" and bank_name in cfg.get("banks", {}):
         try:
             regex_patterns = cfg["banks"][bank_name]["regex"]
-            amount_match = re.search(regex_patterns["amount"], email_text)
-            description_match = re.search(regex_patterns["description"], email_text)
+
+            amount_match = description_match = None
+
+            if isinstance(regex_patterns, list):
+                for pat in regex_patterns:
+                    if not isinstance(pat, dict):
+                        continue
+                    a_match = re.search(pat.get("amount", ""), email_text)
+                    d_match = re.search(pat.get("description", ""), email_text)
+                    if a_match and d_match:
+                        amount_match = a_match
+                        description_match = d_match
+                        break
+            else:
+                amount_match = re.search(regex_patterns["amount"], email_text)
+                description_match = re.search(regex_patterns["description"], email_text)
+
             extracted_data["amount"] = (
                 amount_match.group(1).replace(",", ".") if amount_match else None
             )

--- a/client/src/components/EmailExtractionPage.jsx
+++ b/client/src/components/EmailExtractionPage.jsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { emailService } from '../Services/emailService';
 import { useTransactions } from '../hooks/useTransactions';
 import { AlertTriangle } from 'lucide-react';
+import EmailViewerModal from './common/EmailViewerModal';
 
 const EmailExtractionPage = () => {
   const { t } = useTranslation();
@@ -14,6 +15,8 @@ const EmailExtractionPage = () => {
   const [loading, setLoading] = useState(false);
   const [processing, setProcessing] = useState(false);
   const [progress, setProgress] = useState(0);
+  const [showEmailModal, setShowEmailModal] = useState(false);
+  const [modalHtml, setModalHtml] = useState('');
 
   const { refreshTransactions } = useTransactions();
 
@@ -58,6 +61,16 @@ const EmailExtractionPage = () => {
         .filter((id) => id !== idxToRemove)
         .map((id) => (id > idxToRemove ? id - 1 : id))
     );
+  };
+
+  const viewEmail = (html) => {
+    setModalHtml(html);
+    setShowEmailModal(true);
+  };
+
+  const closeEmailModal = () => {
+    setShowEmailModal(false);
+    setModalHtml('');
   };
 
   const clearQueue = () => {
@@ -184,6 +197,7 @@ const EmailExtractionPage = () => {
                 <th className="px-6 py-3">{t('queue.table.amount')}</th>
                 <th className="px-6 py-3">{t('queue.table.description')}</th>
                 <th className="px-6 py-3">{t('queue.table.bank')}</th>
+                <th className="px-6 py-3">{t('queue.table.viewEmail')}</th>
                 <th className="px-6 py-3">{t('queue.table.duplicate')}</th>
                 <th className="px-6 py-3">{t('queue.table.remove')}</th>
               </tr>
@@ -205,6 +219,14 @@ const EmailExtractionPage = () => {
                   <td className="px-6 py-4">{item.transaction.amount}</td>
                   <td className="px-6 py-4">{item.transaction.description}</td>
                   <td className="px-6 py-4">{item.transaction.bank}</td>
+                  <td className="px-6 py-4">
+                    <button
+                      onClick={() => viewEmail(item.transaction.full_email)}
+                      className="text-blue-600 hover:underline"
+                    >
+                      {t('queue.table.viewEmail')}
+                    </button>
+                  </td>
                   <td className="px-6 py-4 text-red-600 flex items-center gap-1">
                     {item.transaction.duplicate && <AlertTriangle className="w-4 h-4" />}
                     {item.transaction.duplicate ? t('queue.table.duplicateYes') : t('queue.table.duplicateNo')}
@@ -228,6 +250,11 @@ const EmailExtractionPage = () => {
           )}
         </div>
       )}
+      <EmailViewerModal
+        isOpen={showEmailModal}
+        onClose={closeEmailModal}
+        html={modalHtml}
+      />
     </div>
   );
 };

--- a/client/src/components/common/EmailViewerModal.jsx
+++ b/client/src/components/common/EmailViewerModal.jsx
@@ -2,13 +2,20 @@ import React, { useState, useEffect } from 'react';
 import { X } from 'lucide-react';
 import { apiClient } from '../../Services/api';
 
-const EmailViewerModal = ({ isOpen, onClose, transaction }) => {
+const EmailViewerModal = ({ isOpen, onClose, transaction, html }) => {
   const [emailHtml, setEmailHtml] = useState('');
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     const fetchEmail = async () => {
-      if (isOpen && transaction) {
+      if (!isOpen) return;
+
+      if (html) {
+        setEmailHtml(html);
+        return;
+      }
+
+      if (transaction) {
         try {
           setLoading(true);
           const data = await apiClient.get(`/api/transactions/${transaction.id}/email`);
@@ -22,7 +29,7 @@ const EmailViewerModal = ({ isOpen, onClose, transaction }) => {
       }
     };
     fetchEmail();
-  }, [isOpen, transaction]);
+  }, [isOpen, transaction, html]);
 
   if (!isOpen) return null;
 

--- a/client/src/components/common/__tests__/EmailViewerModal.test.jsx
+++ b/client/src/components/common/__tests__/EmailViewerModal.test.jsx
@@ -40,4 +40,27 @@ describe('EmailViewerModal', () => {
       expect(screen.getByText('Hello World')).toBeInTheDocument();
     });
   });
+
+  it('displays provided HTML without fetching when html prop is used', async () => {
+    const htmlContent = '<p>Preview</p>';
+
+    const Wrapper = () => {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button onClick={() => setOpen(true)}>Show Email</button>
+          <EmailViewerModal isOpen={open} onClose={() => setOpen(false)} html={htmlContent} />
+        </>
+      );
+    };
+
+    render(<Wrapper />);
+
+    await userEvent.click(screen.getByText('Show Email'));
+
+    expect(apiClient.get).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.getByText('Preview')).toBeInTheDocument();
+    });
+  });
 });

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -57,6 +57,7 @@
   ,"queue.table.amount": "Amount"
   ,"queue.table.description": "Description"
   ,"queue.table.bank": "Bank"
+  ,"queue.table.viewEmail": "View Email"
   ,"queue.table.duplicate": "Duplicate"
   ,"queue.table.duplicateYes": "Yes"
   ,"queue.table.duplicateNo": "No"

--- a/client/src/locales/fr/translation.json
+++ b/client/src/locales/fr/translation.json
@@ -57,6 +57,7 @@
   ,"queue.table.amount": "Montant"
   ,"queue.table.description": "Description"
   ,"queue.table.bank": "Banque"
+  ,"queue.table.viewEmail": "Voir le courriel"
   ,"queue.table.duplicate": "Dupliquer"
   ,"queue.table.duplicateYes": "Oui"
   ,"queue.table.duplicateNo": "Non"


### PR DESCRIPTION
## Summary
- support regex lists in `extract_transaction_data`
- add test for Neo Financial config using multi-regex
- allow previewing raw HTML emails before processing

## Testing
- `pytest Application/tests/test_traitement.py -q`
- `npm test --prefix client --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_686c694215c8832bb165dd6033bde569