### PR TITLE
Add exclude keyword support in email classification

### DIFF
--- a/Application/config.yml
+++ b/Application/config.yml
@@ -16,6 +16,10 @@ banks:
   capital_one_credit:
     sender: "capitalone@notification.capitalone.com"
     keywords: ["A transaction was charged to your account", "International transaction alert"]
+    exclude_keywords:
+      - "Payment posted"
+      - "Paiement inscrit"
+      - "Thank you for your payment"
     regex:
       amount: "\\$?([0-9]+[,.][0-9]{2})\\$?"
       description: "([A-Z0-9#&\\- ]+)(?=\\s*\\$?[0-9]+[,.][0-9]{2}\\$?)"

--- a/Application/emailextract.py
+++ b/Application/emailextract.py
@@ -37,16 +37,23 @@ def extract_email_body(my_msg):
     return body if body else "No body content found"
 
 def is_transaction_email(sender, subject, config):
-    """Check if an email is a transaction based on sender and subject keywords."""
+    """Check if an email is a transaction based on sender and subject keywords.
+
+    ``exclude_keywords`` are evaluated first and cause the function to
+    immediately return ``False`` if any are found in the subject.
+    """
     # Find matching bank configuration
     for bank_name, bank_config in config["banks"].items():
         if bank_config["sender"].lower() == sender.lower():
-            # Check if any keyword matches the subject
+            for ex_kw in bank_config.get("exclude_keywords", []):
+                if ex_kw.lower() in subject.lower():
+                    return False, None, None
+
             keywords = bank_config["keywords"]
             for keyword in keywords:
                 if keyword.lower() in subject.lower():
                     return True, bank_name, keyword
-    
+
     return False, None, None
 
 def fetch_emails_by_date_range():

--- a/Application/emailextractor.py
+++ b/Application/emailextractor.py
@@ -108,15 +108,25 @@ def decode_email_subject(msg):
         return f"Subject decode error: {str(e)}"
 
 def is_transaction_email(sender, subject, content, config):
-    """Check if email is a transaction based on sender and keywords."""
+    """Check if email is a transaction based on sender and keywords.
+
+    Any phrase defined in ``exclude_keywords`` for the bank will cause the
+    function to immediately return ``False`` when found in the subject or body.
+    """
     try:
         for bank_name, bank_config in config["banks"].items():
             if bank_config["sender"].lower() == sender.lower():
+                for ex_kw in bank_config.get("exclude_keywords", []):
+                    if ex_kw.lower() in subject.lower() or ex_kw.lower() in content.lower():
+                        return False, None, None
+
                 keywords = bank_config["keywords"]
                 for keyword in keywords:
-                    if (keyword.lower() in subject.lower() or 
+                    if (keyword.lower() in subject.lower() or
                         keyword.lower() in content.lower()):
                         return True, bank_name, keyword
+                return False, None, None
+
         return False, None, None
     except Exception:
         return False, None, None

--- a/Application/tests/test_email_classification.py
+++ b/Application/tests/test_email_classification.py
@@ -1,0 +1,27 @@
+import os
+import sys
+# Ensure Application modules can be imported
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from Realtransactions import load_config, is_transaction_email
+
+
+def test_exclude_keyword_blocks_transaction():
+    config = load_config()
+    sender = config["banks"]["capital_one_credit"]["sender"]
+    subject = "Payment posted to your account"
+    content = "Thank you for your payment of $50."
+
+    assert is_transaction_email(sender, subject, content, config) == (False, None, None)
+
+
+def test_positive_keyword_still_detected():
+    config = load_config()
+    sender = config["banks"]["capital_one_credit"]["sender"]
+    subject = "A transaction was charged to your account"
+    content = "Purchase of $10 at STORE"
+
+    result = is_transaction_email(sender, subject, content, config)
+    assert result[0] is True
+    assert result[1] == "capital_one_credit"
+

--- a/README.md
+++ b/README.md
@@ -24,9 +24,29 @@ Assurez-vous que **Python 3** est installé et accessible depuis votre ligne de 
    ```
 3. Exécuter les scripts d’extraction situés dans le dossier `Application` avec Python 3 :
    ```bash
-   ${PYTHON_CMD:-python} Application/main.py
-   ```
-   Remplacez `main.py` par le script de votre choix. Définissez `PYTHON_CMD` si `python` ne pointe pas vers Python 3 sur votre système.
+\${PYTHON_CMD:-python} Application/main.py
+```
+Remplacez `main.py` par le script de votre choix. Définissez `PYTHON_CMD` si `python` ne pointe pas vers Python 3 sur votre système.
+
+## Configuration des banques
+
+Les banques prises en charge sont déclarées dans `Application/config.yml`. Chaque section contient l’adresse courriel de l’expéditeur ainsi qu’une liste de `keywords` indiquant qu’un courriel décrit une transaction.
+
+Vous pouvez également définir une liste optionnelle `exclude_keywords` pour signaler des phrases qui **ne** doivent pas être considérées comme des transactions (par exemple les confirmations de paiement).
+
+Exemple :
+
+```yaml
+  capital_one_credit:
+    sender: "capitalone@notification.capitalone.com"
+    keywords: ["A transaction was charged to your account", "International transaction alert"]
+    exclude_keywords:
+      - "Payment posted"
+      - "Paiement inscrit"
+      - "Thank you for your payment"
+```
+
+Si l’objet ou le contenu d’un courriel contient l’une de ces expressions, il sera marqué comme **non transactionnel** même s’il contient un mot clé positif.
 
 ## Exécution du client React et du serveur Node
 


### PR DESCRIPTION
## Summary
- allow optional `exclude_keywords` for banks in config
- prevent classification of payment emails using new exclude list
- document exclude keyword usage in README
- test that exclude keywords override positive matches

## Testing
- `pip install -r requirements.txt`
- `pip install pytest`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688918d3f55c832bae5b8cb3667ebf98