### PR TITLE
Update regex to allow mixed-case descriptions

### DIFF
--- a/Application/config.yml
+++ b/Application/config.yml
@@ -4,14 +4,14 @@ banks:
     keywords: ["Achat en point de vente", "achat international"]
     regex: 
       amount: "Montant de l'achat\\s*:\\s*(\\d+[,.]\\d{2})\\$"
-      description: "Lieu de l'achat\\s*:\\s*(.*?)\\r?\\n"
+      description: "Lieu de l'achat\\s*:\\s*([A-Za-z0-9#&\\- ]+)\\r?\\n"
 
   cibc_credit:
     sender: "mailbox.noreply@cibc.com"
     keywords: ["Nouvel achat avec votre carte de"]
     regex:
       amount: "achat de\\s*\\$?([0-9]+[,.][0-9]{2})\\$?"
-      description: "achat de\\s*\\$?[0-9]+[,.][0-9]{2}\\$?\\s*(.*?)\\s+avec votre"
+      description: "achat de\\s*\\$?[0-9]+[,.][0-9]{2}\\$?\\s*([A-Za-z0-9#&\\- ]+)\\s+avec votre"
 
   capital_one_credit:
     sender: "capitalone@notification.capitalone.com"
@@ -22,14 +22,14 @@ banks:
       - "Thank you for your payment"
     regex:
       amount: "\\$?([0-9]+[,.][0-9]{2})\\$?"
-      description: "([A-Z0-9#&\\- ]+)(?=\\s*\\$?[0-9]+[,.][0-9]{2}\\$?)"
+      description: "([A-Za-z0-9#&\\- ]+)(?=\\s*\\$?[0-9]+[,.][0-9]{2}\\$?)"
 
   mbna_credit:
     sender: "noreply@mbna.ca"
     keywords: ["Transaction Alert", "Purchase Notification", "MBNA - Transaction Alert"]
     regex:
       amount: "\\$([0-9]+\\.[0-9]{2})"
-      description: "from ([A-Z0-9/& ]+)"
+      description: "from ([A-Za-z0-9/& ]+)"
 
   neo_credit:
     sender: "info@neofinancial.com"

--- a/Application/tests/test_description_extraction.py
+++ b/Application/tests/test_description_extraction.py
@@ -1,0 +1,41 @@
+import os
+import sys
+
+# Ensure Application modules can be imported
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from traitement import extract_transaction_data
+
+
+def _extract(bank_key: str, html: str):
+    data = {"bank_config": bank_key, "full_email_html": html}
+    return extract_transaction_data(data)
+
+
+def test_capital_one_mixed_case_description():
+    result = _extract("capital_one_credit", "MixedCaseVendor $10.00")
+    assert result["description"] == "MixedCaseVendor"
+
+
+def test_mbna_mixed_case_description():
+    result = _extract("mbna_credit", "You made a purchase of $9.99 from MixedCaseVendor")
+    assert result["description"] == "MixedCaseVendor"
+
+
+def test_cibc_debit_mixed_case_description():
+    html = "Montant de l'achat : 25,99$\nLieu de l'achat : MixedCaseStore\n"
+    result = _extract("cibc_debit", html)
+    assert result["description"] == "MixedCaseStore"
+
+
+def test_cibc_credit_mixed_case_description():
+    html = "achat de $12.34 MixedCaseVendor avec votre carte"
+    result = _extract("cibc_credit", html)
+    assert result["description"] == "MixedCaseVendor"
+
+
+def test_neo_credit_mixed_case_description():
+    html = "You made a purchase of $5.55 at MixedCaseStore"
+    result = _extract("neo_credit", html)
+    assert result["description"] == "MixedCaseStore"
+


### PR DESCRIPTION
## Summary
- allow lowercase letters in bank regex patterns
- cover mixed-case vendor names in unit tests

## Testing
- `pytest Application -q`

------
https://chatgpt.com/codex/tasks/task_e_688929ebe12c832b8e9549d1662d8c18