### PR TITLE
feat: persist keyword-based rules

### DIFF
--- a/Database/Database.py
+++ b/Database/Database.py
@@ -73,6 +73,15 @@ def create_database():
         )
     """)
 
+    # ✅ Create keyword_rules table to store automatic categorization/tagging rules
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS keyword_rules (
+            keyword TEXT PRIMARY KEY,
+            category TEXT,
+            tags TEXT
+        )
+    """)
+
     conn.commit()
     conn.close()
     print("✅ SQLite database and tables created successfully!")


### PR DESCRIPTION
## Summary
- create `keyword_rules` table to store auto-categorization/tag rules
- record applied keyword category/tags as rules
- expose endpoints to list, update and delete keyword rules

## Testing
- `pytest`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6892b508438c832bbcfc457851579a8f