### PR TITLE
Define keyword_rules table schema

### DIFF
--- a/Database/Database.py
+++ b/Database/Database.py
@@ -76,8 +76,7 @@ def create_database():
     # ✅ Create keyword_rules table for automatic categorization and tagging
     cursor.execute("""
         CREATE TABLE IF NOT EXISTS keyword_rules (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            keyword TEXT NOT NULL UNIQUE,
+            keyword TEXT PRIMARY KEY,
             category TEXT,
             tags TEXT
         )


### PR DESCRIPTION
## Summary
- Clean up merge conflict markers and redefine `keyword_rules` table to use `keyword` as the primary key with `category` and `tags`

## Testing
- `pytest`
- `npm test -- --watchAll=false` *(fails: 1 test)*

------
https://chatgpt.com/codex/tasks/task_e_6892bdf0751c832b8131306694724e7c