### PR TITLE
Add keyword_rules table to database initialization

### DIFF
--- a/Database/Database.py
+++ b/Database/Database.py
@@ -73,6 +73,17 @@ def create_database():
         )
     """)
 
+    # ✅ Create keyword_rules table for automatic categorization/tagging
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS keyword_rules (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            keyword TEXT NOT NULL,
+            target_type TEXT CHECK(target_type IN ('category','tag')) NOT NULL,
+            target_value TEXT NOT NULL,
+            active INTEGER DEFAULT 1
+        )
+    """)
+
     conn.commit()
     conn.close()
     print("✅ SQLite database and tables created successfully!")


### PR DESCRIPTION
## Summary
- add `keyword_rules` table with keyword, target type, target value and activation fields
- initialize `keyword_rules` during database setup

## Testing
- `python3 Database/Database.py`
- `npm test --prefix Server` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b894c7a76c832bb4fe01c531b74b48