### PR TITLE
Apply keyword rules during transaction insertion

### DIFF
--- a/Database/Insert.py
+++ b/Database/Insert.py
@@ -7,6 +7,23 @@ if not logging.getLogger().handlers:
     logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+# Cache for active keyword rules
+ACTIVE_RULES = None
+
+
+def get_active_rules(cursor):
+    """Fetch active keyword rules once and cache them."""
+    global ACTIVE_RULES
+    if ACTIVE_RULES is None:
+        cursor.execute(
+            "SELECT keyword, target_type, target_value FROM keyword_rules WHERE active = 1"
+        )
+        rows = cursor.fetchall()
+        ACTIVE_RULES = [
+            {"keyword": r[0], "target_type": r[1], "target_value": r[2]} for r in rows
+        ]
+    return ACTIVE_RULES
+
 def insert_transaction(ordered_data):
     """
     Inserts a transaction into the database and associates it with relevant tags.
@@ -24,37 +41,56 @@ def insert_transaction(ordered_data):
 
         # ✅ Assign a category (if not provided, default to 'Uncategorized')
         category = ordered_data.get("category", "Uncategorized")
+        tags = ordered_data.get("tags", [])  # Retrieve tags if present
+
+        # ✅ Apply keyword rules before inserting
+        description_lower = ordered_data["description"].lower()
+        for rule in get_active_rules(cursor):
+            if rule["keyword"].lower() in description_lower:
+                if rule["target_type"] == "category":
+                    category = rule["target_value"]
+                elif rule["target_type"] == "tag":
+                    tags.append(rule["target_value"])
+
+        # Remove duplicate tags while preserving order
+        tags = list(dict.fromkeys(tags))
 
         # ✅ Get or create transaction entry
-        cursor.execute("""
+        cursor.execute(
+            """
             INSERT INTO transactions (amount, description, card_type, date, time, bank, full_email, category)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-        """, (
-            amount,
-            ordered_data["description"],
-            ordered_data["card type"],
-            ordered_data["date"],
-            ordered_data.get("time", None),  # ✅ Allow NULL time
-            ordered_data["bank"],
-            ordered_data.get("full_email", "No email content"),
-            category
-        ))
+        """,
+            (
+                amount,
+                ordered_data["description"],
+                ordered_data["card type"],
+                ordered_data["date"],
+                ordered_data.get("time", None),  # ✅ Allow NULL time
+                ordered_data["bank"],
+                ordered_data.get("full_email", "No email content"),
+                category,
+            ),
+        )
 
         # ✅ Get the inserted transaction ID
         transaction_id = cursor.lastrowid
 
         # ✅ Insert tags and associate them with the transaction
-        tags = ordered_data.get("tags", [])  # Retrieve tags if present
-
         for tag in tags:
-            cursor.execute("INSERT OR IGNORE INTO tags (tag_name) VALUES (?)", (tag,))  # Ensure tag exists
+            cursor.execute(
+                "INSERT OR IGNORE INTO tags (tag_name) VALUES (?)", (tag,)
+            )  # Ensure tag exists
 
             # Retrieve tag ID
             cursor.execute("SELECT id FROM tags WHERE tag_name = ?", (tag,))
             tag_id = cursor.fetchone()[0]
 
             # Link transaction to tag
-            cursor.execute("INSERT INTO transaction_tags (transaction_id, tag_id) VALUES (?, ?)", (transaction_id, tag_id))
+            cursor.execute(
+                "INSERT INTO transaction_tags (transaction_id, tag_id) VALUES (?, ?)",
+                (transaction_id, tag_id),
+            )
 
         conn.commit()
         logger.info("Transaction saved: %s", ordered_data)


### PR DESCRIPTION
## Summary
- cache active keyword rules on server and apply them before inserting transactions
- load keyword rules once in Python import scripts and auto-assign categories or tags

## Testing
- `npm test --prefix Server` *(fails: Error: no test specified)*
- `python -m py_compile Database/Insert.py Transactions/import_json.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8961efa60832bb3dea08a781cef52