### PR TITLE
feat: prompt to create keyword rules after tagging or categorizing

### DIFF
--- a/client/src/Services/ruleService.js
+++ b/client/src/Services/ruleService.js
@@ -1,0 +1,7 @@
+import { apiClient } from './api';
+
+export const ruleService = {
+  create: (keyword, target_type, target_value) =>
+    apiClient.post('/api/rules', { keyword, target_type, target_value }),
+};
+

--- a/client/src/components/TransactionDashboard.jsx
+++ b/client/src/components/TransactionDashboard.jsx
@@ -16,6 +16,7 @@ import TagEditModal from './common/TagEditModal';
 // Add these imports with your existing ones:
 import { useCategories } from '../hooks/useCategories';
 import { useTags } from '../hooks/useTags';
+import { ruleService } from '../Services/ruleService';
 
 
 const TransactionDashboard = () => {
@@ -338,6 +339,13 @@ const handleSaveEdit = async (transaction, field) => {
         // Category is created automatically when assigned to transaction
       }
       await updateCategory(transaction.id, newValue);
+      if (window.confirm(`Create rule for keyword ${transaction.description}?`)) {
+        try {
+          await ruleService.create(transaction.description, 'category', newValue);
+        } catch (err) {
+          console.error('Failed to create rule:', err);
+        }
+      }
     } else if (field === 'amount') {
       await updateAmount(transaction.id, parseFloat(newValue));
     } else if (field === 'description') {

--- a/client/src/components/common/TagEditModal.jsx
+++ b/client/src/components/common/TagEditModal.jsx
@@ -1,6 +1,7 @@
 // src/components/common/TagEditModal.jsx
 import React, { useState, useEffect } from 'react';
 import { X, Plus, Trash2 } from 'lucide-react';
+import { ruleService } from '../../Services/ruleService';
 
 const TagEditModal = ({ 
   isOpen, 
@@ -32,6 +33,13 @@ const TagEditModal = ({
       setIsLoading(true);
       await addTag(transaction.id, tagName);
       setCurrentTags(prev => [...prev, tagName]);
+      if (window.confirm(`Create rule for keyword ${transaction.description}?`)) {
+        try {
+          await ruleService.create(transaction.description, 'tag', tagName);
+        } catch (err) {
+          console.error('Failed to create rule:', err);
+        }
+      }
     } catch (error) {
       console.error('Failed to add tag:', error);
       alert('Failed to add tag. Please try again.');
@@ -63,6 +71,13 @@ const TagEditModal = ({
       setIsLoading(true);
       await addTag(transaction.id, newTagName.trim());
       setCurrentTags(prev => [...prev, newTagName.trim()]);
+      if (window.confirm(`Create rule for keyword ${transaction.description}?`)) {
+        try {
+          await ruleService.create(transaction.description, 'tag', newTagName.trim());
+        } catch (err) {
+          console.error('Failed to create rule:', err);
+        }
+      }
       setNewTagName('');
     } catch (error) {
       console.error('Failed to add new tag:', error);


### PR DESCRIPTION
## Summary
- add ruleService for calling `/api/rules`
- ask user to create a rule after adding tags or categories

## Testing
- `cd client && CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b89b1596e0832b90e1601b73021135