### PR TITLE
feat: save keyword rules after tag or category edits

### DIFF
--- a/client/src/Services/keywordMappingService.js
+++ b/client/src/Services/keywordMappingService.js
@@ -6,5 +6,8 @@ export const keywordMappingService = {
   },
   applyTags: async (keyword, tags) => {
     return apiClient.post('/api/apply-keyword-tags', { keyword, tags });
+  },
+  createRule: async (keyword, mapping) => {
+    return apiClient.post('/api/rules', { keyword, ...mapping });
   }
 };

--- a/client/src/components/TransactionDashboard.jsx
+++ b/client/src/components/TransactionDashboard.jsx
@@ -16,6 +16,7 @@ import TagEditModal from './common/TagEditModal';
 // Add these imports with your existing ones:
 import { useCategories } from '../hooks/useCategories';
 import { useTags } from '../hooks/useTags';
+import { keywordMappingService } from '../Services/keywordMappingService';
 
 
 const TransactionDashboard = () => {
@@ -335,6 +336,15 @@ const handleSaveEdit = async (transaction, field) => {
 
       }
       await updateCategory(transaction.id, newValue);
+      if (window.confirm('Save this keyword rule?')) {
+        try {
+          await keywordMappingService.createRule(transaction.description, { category: newValue });
+          alert('Keyword rule saved!');
+        } catch (ruleError) {
+          console.error('Failed to save keyword rule:', ruleError);
+          alert('Failed to save keyword rule.');
+        }
+      }
     } else if (field === 'amount') {
       await updateAmount(transaction.id, parseFloat(newValue));
     } else if (field === 'description') {

--- a/client/src/components/common/TagEditModal.jsx
+++ b/client/src/components/common/TagEditModal.jsx
@@ -1,6 +1,7 @@
 // src/components/common/TagEditModal.jsx
 import React, { useState, useEffect } from 'react';
 import { X, Plus, Trash2 } from 'lucide-react';
+import { keywordMappingService } from '../../Services/keywordMappingService';
 
 const TagEditModal = ({ 
   isOpen, 
@@ -27,11 +28,20 @@ const TagEditModal = ({
 
   const handleAddExistingTag = async (tagName) => {
     if (currentTags.includes(tagName)) return;
-    
+
     try {
       setIsLoading(true);
       await addTag(transaction.id, tagName);
       setCurrentTags(prev => [...prev, tagName]);
+      if (window.confirm('Save this keyword rule?')) {
+        try {
+          await keywordMappingService.createRule(transaction.description, { tags: [tagName] });
+          alert('Keyword rule saved!');
+        } catch (ruleError) {
+          console.error('Failed to save keyword rule:', ruleError);
+          alert('Failed to save keyword rule.');
+        }
+      }
     } catch (error) {
       console.error('Failed to add tag:', error);
       alert('Failed to add tag. Please try again.');
@@ -61,9 +71,19 @@ const TagEditModal = ({
 
     try {
       setIsLoading(true);
-      await addTag(transaction.id, newTagName.trim());
-      setCurrentTags(prev => [...prev, newTagName.trim()]);
+      const tag = newTagName.trim();
+      await addTag(transaction.id, tag);
+      setCurrentTags(prev => [...prev, tag]);
       setNewTagName('');
+      if (window.confirm('Save this keyword rule?')) {
+        try {
+          await keywordMappingService.createRule(transaction.description, { tags: [tag] });
+          alert('Keyword rule saved!');
+        } catch (ruleError) {
+          console.error('Failed to save keyword rule:', ruleError);
+          alert('Failed to save keyword rule.');
+        }
+      }
     } catch (error) {
       console.error('Failed to add new tag:', error);
       alert('Failed to add new tag. Please try again.');


### PR DESCRIPTION
## Summary
- prompt users to save keyword mapping after adding a tag or changing category
- create keyword mapping rule via `keywordMappingService.createRule`
- alert users when the keyword rule is saved

## Testing
- `npm test -- --watchAll=false` *(fails: 1 failed, 2 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b89dfff088832b9bdf776fd1955b47