### PR TITLE
feat: prompt for keyword rule when editing tags

### DIFF
--- a/client/src/components/common/TagEditModal.jsx
+++ b/client/src/components/common/TagEditModal.jsx
@@ -1,6 +1,8 @@
 // src/components/common/TagEditModal.jsx
 import React, { useState, useEffect } from 'react';
 import { X, Plus, Trash2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { keywordMappingService } from '../../Services/keywordMappingService';
 
 const TagEditModal = ({ 
   isOpen, 
@@ -14,6 +16,19 @@ const TagEditModal = ({
   const [currentTags, setCurrentTags] = useState([]);
   const [newTagName, setNewTagName] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const { t } = useTranslation();
+
+  const promptAndSaveRule = async (updatedTags) => {
+    if (window.confirm(t('tagEdit.saveKeywordRulePrompt'))) {
+      try {
+        await keywordMappingService.createRule(transaction.description, null, updatedTags);
+        alert(t('tagEdit.keywordRuleSuccess'));
+      } catch (err) {
+        console.error('Failed to save keyword rule:', err);
+        alert(t('tagEdit.keywordRuleError'));
+      }
+    }
+  };
 
   // Initialize current tags when modal opens
   useEffect(() => {
@@ -31,7 +46,9 @@ const TagEditModal = ({
     try {
       setIsLoading(true);
       await addTag(transaction.id, tagName);
-      setCurrentTags(prev => [...prev, tagName]);
+      const updatedTags = [...currentTags, tagName];
+      setCurrentTags(updatedTags);
+      await promptAndSaveRule(updatedTags);
     } catch (error) {
       console.error('Failed to add tag:', error);
       alert('Failed to add tag. Please try again.');
@@ -44,7 +61,9 @@ const TagEditModal = ({
     try {
       setIsLoading(true);
       await removeTag(transaction.id, tagName);
-      setCurrentTags(prev => prev.filter(tag => tag !== tagName));
+      const updatedTags = currentTags.filter(tag => tag !== tagName);
+      setCurrentTags(updatedTags);
+      await promptAndSaveRule(updatedTags);
     } catch (error) {
       console.error('Failed to remove tag:', error);
       alert('Failed to remove tag. Please try again.');
@@ -62,8 +81,10 @@ const TagEditModal = ({
     try {
       setIsLoading(true);
       await addTag(transaction.id, newTagName.trim());
-      setCurrentTags(prev => [...prev, newTagName.trim()]);
+      const updatedTags = [...currentTags, newTagName.trim()];
+      setCurrentTags(updatedTags);
       setNewTagName('');
+      await promptAndSaveRule(updatedTags);
     } catch (error) {
       console.error('Failed to add new tag:', error);
       alert('Failed to add new tag. Please try again.');

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -86,4 +86,7 @@
   ,"mappings.rules.save": "Save"
   ,"mappings.rules.cancel": "Cancel"
   ,"mappings.rules.noRules": "No rules defined"
+  ,"tagEdit.saveKeywordRulePrompt": "Save a keyword rule for this description?"
+  ,"tagEdit.keywordRuleSuccess": "Keyword rule saved"
+  ,"tagEdit.keywordRuleError": "Failed to save keyword rule"
 }

--- a/client/src/locales/fr/translation.json
+++ b/client/src/locales/fr/translation.json
@@ -86,4 +86,7 @@
   ,"mappings.rules.save": "Enregistrer"
   ,"mappings.rules.cancel": "Annuler"
   ,"mappings.rules.noRules": "Aucune règle définie"
+  ,"tagEdit.saveKeywordRulePrompt": "Enregistrer une règle de mot-clé pour cette description ?"
+  ,"tagEdit.keywordRuleSuccess": "Règle de mot-clé enregistrée"
+  ,"tagEdit.keywordRuleError": "Échec de l'enregistrement de la règle de mot-clé"
 }


### PR DESCRIPTION
## Summary
- prompt users to save a keyword rule after editing tags
- create rule via `keywordMappingService.createRule` with transaction description and tags
- add i18n strings for rule prompt and feedback in English and French

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68b8a29e2254832bbd9d557c2aaeba4f