### PR TITLE
Avoid duplicate rule creation in mapping settings

### DIFF
--- a/client/src/components/Settings/MappingsSettings.jsx
+++ b/client/src/components/Settings/MappingsSettings.jsx
@@ -53,7 +53,6 @@ const MappingsSettings = () => {
       setLoadingCat(true);
       const res = await keywordMappingService.applyCategory(keywordCat, selectedCategory);
       setCategoryResult(res.updatedTransactions);
-      await keywordMappingService.createRule(keywordCat, selectedCategory, []);
       await loadRules();
     } catch (err) {
       alert('Failed to apply category: ' + err.message);
@@ -74,7 +73,6 @@ const MappingsSettings = () => {
       setLoadingTags(true);
       const res = await keywordMappingService.applyTags(keywordTags, selectedTags);
       setTagsResult(res.updatedTransactions);
-      await keywordMappingService.createRule(keywordTags, null, selectedTags);
       await loadRules();
     } catch (err) {
       alert('Failed to apply tags: ' + err.message);


### PR DESCRIPTION
## Summary
- remove redundant `keywordMappingService.createRule` calls in MappingsSettings apply handlers
- rely on `applyCategory` and `applyTags` for persistence and refresh rules after applying

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b8cc00a580832b91e53ba53e924a88