### PR TITLE
Patch 1: Harden email extraction, credentials, dashboard stats, and tag idempotency

### DIFF
--- a/Application/extracteur.py
+++ b/Application/extracteur.py
@@ -14,7 +14,7 @@ import yaml
 import os
 from bs4 import BeautifulSoup
 from email.header import decode_header
-from datetime import datetime
+from datetime import datetime, timedelta
 
 # ✅ Définissez ici l'expéditeur et la position de l'e-mail à extraire
 SENDER_EMAIL = "info@neofinancial.com"  # Modifiez cette valeur selon l'expéditeur souhaité
@@ -39,6 +39,52 @@ def extract_email_body(my_msg):
 
     return body if body else "No body content found"
 
+
+
+def _load_email_credentials():
+    """Load IMAP credentials, preferring environment variables only.
+
+    credentials.yml is supported only when ALLOW_PLAINTEXT_CREDENTIALS=1 is
+    explicitly set for local development.
+    """
+    user = os.getenv("EMAIL_USER")
+    password = os.getenv("EMAIL_PASS")
+    if user and password:
+        return user, password
+
+    if os.getenv("ALLOW_PLAINTEXT_CREDENTIALS") == "1":
+        base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        credentials_path = os.path.join(base_dir, "credentials.yml")
+        if os.path.exists(credentials_path):
+            with open(credentials_path, "r", encoding="utf-8") as f:
+                creds = yaml.safe_load(f) or {}
+            user = user or creds.get("user")
+            password = password or creds.get("password")
+            if user and password:
+                return user, password
+
+    raise ValueError(
+        "Email credentials not provided. Set EMAIL_USER and EMAIL_PASS. "
+        "Plaintext credentials.yml is disabled unless ALLOW_PLAINTEXT_CREDENTIALS=1 for local dev."
+    )
+
+
+def _imap_before_date_inclusive(end_date: str) -> str:
+    """Convert inclusive end date (DD-Mon-YYYY) to IMAP BEFORE date (exclusive)."""
+    end_dt = datetime.strptime(end_date, "%d-%b-%Y")
+    return (end_dt + timedelta(days=1)).strftime("%d-%b-%Y")
+
+
+def _is_excluded_email(bank_cfg: dict, subject: str, content: str) -> bool:
+    """Return True when subject/body contains any configured exclude keyword."""
+    subject_l = (subject or "").lower()
+    content_l = (content or "").lower()
+    for keyword in bank_cfg.get("exclude_keywords", []):
+        if keyword.lower() in subject_l or keyword.lower() in content_l:
+            return True
+    return False
+
+
 def fetch_emails(start_date: str, end_date: str):
     """Retrieve HTML emails from all configured banks within a date range.
 
@@ -61,23 +107,7 @@ def fetch_emails(start_date: str, end_date: str):
     mail = imaplib.IMAP4_SSL(imap_url)
 
     # Load credentials
-    base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-    credentials_path = os.path.join(base_dir, "credentials.yml")
-
-    user = os.getenv("EMAIL_USER")
-    password = os.getenv("EMAIL_PASS")
-
-    if os.path.exists(credentials_path):
-        with open(credentials_path, "r", encoding="utf-8") as f:
-            creds = yaml.safe_load(f)
-            user = user or creds.get("user")
-            password = password or creds.get("password")
-
-    if not user or not password:
-        raise ValueError(
-            "Email credentials not provided. Set EMAIL_USER and EMAIL_PASS "
-            "environment variables or update credentials.yml"
-        )
+    user, password = _load_email_credentials()
 
     # Login and select inbox
     mail.login(user, password)
@@ -88,6 +118,8 @@ def fetch_emails(start_date: str, end_date: str):
     with open(config_file, "r", encoding="utf-8") as f:
         config = yaml.safe_load(f)
 
+    before_date = _imap_before_date_inclusive(end_date)
+
     fetched_emails = []
 
     for bank_name, bank_cfg in config.get("banks", {}).items():
@@ -95,7 +127,7 @@ def fetch_emails(start_date: str, end_date: str):
         if not sender:
             continue
 
-        search = f'(FROM "{sender}" SINCE "{start_date}" BEFORE "{end_date}")'
+        search = f'(FROM "{sender}" SINCE "{start_date}" BEFORE "{before_date}")'
         _, data = mail.search(None, search)
         mail_ids = data[0].split()
 
@@ -138,6 +170,10 @@ def fetch_emails(start_date: str, end_date: str):
                                     + "</pre>"
                                 )
                             break
+
+                email_text = BeautifulSoup(html_content or "", "html.parser").get_text(separator="\n")
+                if _is_excluded_email(bank_cfg, subject, email_text):
+                    continue
 
                 fetched_emails.append(
                     {

--- a/Application/tests/test_description_extraction.py
+++ b/Application/tests/test_description_extraction.py
@@ -39,3 +39,36 @@ def test_neo_credit_mixed_case_description():
     result = _extract("neo_credit", html)
     assert result["description"] == "MixedCaseStore"
 
+
+
+def test_plain_text_input_does_not_raise_and_preserves_full_email():
+    result = extract_transaction_data("No structured html", email_sender="unknown@example.com", email_subject="No match")
+    assert result["full_email"] == "No structured html"
+
+
+def test_exclude_keywords_block_transaction_parsing():
+    cfg = {
+        "banks": {
+            "capital_one_credit": {
+                "sender": "capitalone@notification.capitalone.com",
+                "keywords": ["A transaction was charged to your account"],
+                "exclude_keywords": ["Payment posted"],
+                "regex": {
+                    "amount": "\\$?([0-9]+[,.][0-9]{2})\\$?",
+                    "description": "([A-Za-z0-9#&\\- ]+)(?=\\s*\\$?[0-9]+[,.][0-9]{2}\\$?)"
+                }
+            }
+        }
+    }
+
+    email_data = {
+        "sender": "capitalone@notification.capitalone.com",
+        "subject": "Payment posted to your account",
+        "full_email_html": "StoreName $10.00",
+        "bank_config": "capital_one_credit"
+    }
+
+    result = extract_transaction_data(email_data, cfg=cfg)
+    assert result["amount"] is None
+    assert result["description"] is None
+    assert result["bank"] == "Unknown"

--- a/Application/tests/test_extracteur_security.py
+++ b/Application/tests/test_extracteur_security.py
@@ -1,0 +1,33 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from extracteur import _imap_before_date_inclusive, _load_email_credentials
+
+
+def test_imap_end_date_is_inclusive_by_advancing_before_date():
+    assert _imap_before_date_inclusive('31-Dec-2025') == '01-Jan-2026'
+
+
+def test_credentials_require_env_vars_by_default(monkeypatch):
+    monkeypatch.delenv('EMAIL_USER', raising=False)
+    monkeypatch.delenv('EMAIL_PASS', raising=False)
+    monkeypatch.delenv('ALLOW_PLAINTEXT_CREDENTIALS', raising=False)
+
+    try:
+        _load_email_credentials()
+    except ValueError as exc:
+        assert 'EMAIL_USER and EMAIL_PASS' in str(exc)
+    else:
+        raise AssertionError('Expected ValueError when EMAIL_USER/EMAIL_PASS are missing')
+
+
+def test_credentials_loaded_from_env(monkeypatch):
+    monkeypatch.setenv('EMAIL_USER', 'user@example.com')
+    monkeypatch.setenv('EMAIL_PASS', 'secret')
+    monkeypatch.delenv('ALLOW_PLAINTEXT_CREDENTIALS', raising=False)
+
+    user, password = _load_email_credentials()
+    assert user == 'user@example.com'
+    assert password == 'secret'

--- a/Application/traitement.py
+++ b/Application/traitement.py
@@ -54,6 +54,16 @@ def is_duplicate(amount: str, date: str) -> bool:
     except Exception:
         return False
 
+def _contains_exclude_keyword(bank_cfg: dict, subject: str, content: str) -> bool:
+    """Return True when email subject/body contains any bank exclude keyword."""
+    subject_l = (subject or "").lower()
+    content_l = (content or "").lower()
+    for keyword in bank_cfg.get("exclude_keywords", []):
+        if keyword.lower() in subject_l or keyword.lower() in content_l:
+            return True
+    return False
+
+
 def extract_transaction_data(
     email_data,
     email_sender: str | None = None,
@@ -84,6 +94,7 @@ def extract_transaction_data(
 
     # Determine whether ``email_data`` is new-style dict or plain text
     bank_key = None
+    html = ""
     if isinstance(email_data, dict):
         email_sender = email_data.get("sender", email_sender)
         email_subject = email_data.get("subject", email_subject)
@@ -100,6 +111,10 @@ def extract_transaction_data(
 
     bank_name = bank_key or identify_bank(email_sender, email_subject)
     extracted_data = {"amount": None, "description": None, "card_type": None}
+
+    bank_cfg = cfg.get("banks", {}).get(bank_name) if bank_name != "Unknown" else None
+    if bank_cfg and _contains_exclude_keyword(bank_cfg, email_subject or "", email_text):
+        bank_name = "Unknown"
 
     if bank_name != "Unknown" and bank_name in cfg.get("banks", {}):
         try:

--- a/Server/Server.js
+++ b/Server/Server.js
@@ -241,16 +241,19 @@ app.post('/api/transactions/:id/tags', async (req, res) => {
             tagId = tagExists.id;
         }
 
-        // Link tag to transaction
-        const insertTagLinkQuery = "INSERT INTO transaction_tags (transaction_id, tag_id) VALUES (?, ?)";
-        await new Promise((resolve, reject) => {
+        // Link tag to transaction idempotently
+        const insertTagLinkQuery = "INSERT OR IGNORE INTO transaction_tags (transaction_id, tag_id) VALUES (?, ?)";
+        const linkChanges = await new Promise((resolve, reject) => {
             db.run(insertTagLinkQuery, [id, tagId], function (err) {
                 if (err) reject(err);
-                resolve();
+                else resolve(this.changes);
             });
         });
 
-        res.json({ message: "Tag added successfully" });
+        res.json({
+            message: linkChanges ? "Tag added successfully" : "Tag already linked to transaction",
+            alreadyLinked: linkChanges === 0
+        });
     } catch (error) {
         console.error("Error adding tag:", error);
         res.status(500).json({ error: "Internal server error" });
@@ -335,16 +338,31 @@ app.put('/api/transactions/:id/category', (req, res) => {
 
 // Dashboard summary stats
 app.get('/api/dashboard/stats', (req, res) => {
-    const queries = {
-        totalTransactions: "SELECT COUNT(*) as count FROM transactions",
-        totalAmount: "SELECT SUM(amount) as total FROM transactions", 
-        totalIncome: "SELECT SUM(amount) as total FROM transactions WHERE amount > 0",
-        totalExpense: "SELECT SUM(ABS(amount)) as total FROM transactions WHERE amount < 0",
-        avgTransaction: "SELECT AVG(amount) as avg FROM transactions"
-    };
-    
-    // Execute all queries and combine results
-    // Implementation similar to your existing patterns
+    const query = `
+        SELECT
+            COUNT(*) AS totalTransactions,
+            COALESCE(SUM(amount), 0) AS totalAmount,
+            COALESCE(SUM(CASE WHEN amount > 0 THEN amount ELSE 0 END), 0) AS totalIncome,
+            COALESCE(SUM(CASE WHEN amount < 0 THEN ABS(amount) ELSE 0 END), 0) AS totalExpense,
+            COALESCE(AVG(amount), 0) AS avgTransaction
+        FROM transactions
+    `;
+
+    db.get(query, [], (err, row) => {
+        if (err) {
+            return res.status(500).json({ error: err.message });
+        }
+
+        const stats = {
+            totalTransactions: Number(row?.totalTransactions || 0),
+            totalAmount: Number(row?.totalAmount || 0),
+            totalIncome: Number(row?.totalIncome || 0),
+            totalExpense: Number(row?.totalExpense || 0),
+            avgTransaction: Number(row?.avgTransaction || 0)
+        };
+
+        res.json(stats);
+    });
 });
 
 // Monthly spending data for charts


### PR DESCRIPTION
### Motivation
- Prevent runtime crashes and false-positive transactions by fixing a non-dict path and enforcing `exclude_keywords` in the email parsing flow. 
- Ensure server endpoints always return valid JSON and behave safely under duplicate requests. 
- Make date ranges intuitive (selected end date inclusive) for email extraction. 
- Remove silent production reliance on plaintext `credentials.yml` and prefer environment credentials to harden secrets handling.

### Description
- Fixed parser safety and exclusion logic in `Application/traitement.py` by initializing the `html` fallback for non-dict inputs and applying an `_contains_exclude_keyword` check before running regex extraction so excluded emails are treated as non-transactions. (file: `Application/traitement.py`)
- Hardened IMAP extraction in `Application/extracteur.py` by adding `_load_email_credentials()` which prefers `EMAIL_USER`/`EMAIL_PASS` and only reads `credentials.yml` when `ALLOW_PLAINTEXT_CREDENTIALS=1`, added `_imap_before_date_inclusive()` to make user-selected end dates inclusive, and applied `_is_excluded_email()` to filter excluded emails before appending results. (file: `Application/extracteur.py`)
- Implemented `/api/dashboard/stats` in `Server/Server.js` with a single aggregate SQL query and safe numeric defaults so the endpoint always returns valid JSON. (file: `Server/Server.js`)
- Made `POST /api/transactions/:id/tags` idempotent by using `INSERT OR IGNORE` for the `transaction_tags` link and returning a clear `alreadyLinked` status in the response. (file: `Server/Server.js`)
- Added focused/ lightweight tests to cover the changes: added `Application/tests/test_extracteur_security.py` and extended `Application/tests/test_description_extraction.py` to assert non-dict behavior and exclude-keyword blocking. (files: `Application/tests/test_extracteur_security.py`, `Application/tests/test_description_extraction.py`)
- Kept architecture and API shapes unchanged; changes are conservative and limited to backend Python/JS files listed above.

### Testing
- Ran Python unit tests: `pytest -q Application/tests/test_description_extraction.py Application/tests/test_email_classification.py Application/tests/test_extracteur_security.py` which completed successfully (`12 passed`).
- Validated Node file syntax with: `node --check Server/Server.js` (no syntax errors).
- Added tests verify inclusive end-date conversion, env-only credential requirement (and env credential success), exclude-keyword filtering during parsing, and plain-text non-dict parser path.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf18bf6b64832b9bbe088256d5a9a7)