### PR TITLE
Normalize transactions/tags from API, add transformers, and make queue selection stable

### DIFF
--- a/client/src/Services/transactionService.js
+++ b/client/src/Services/transactionService.js
@@ -2,13 +2,20 @@
 
 // src/services/transactionService.js - Transaction API calls
 import { apiClient } from './api';
+import { transformTransactionFromApi } from './transformers';
 
 export const transactionService = {
   // Get all transactions
-  getAll: () => apiClient.get('/api/transactions'),
+  getAll: async () => {
+    const result = await apiClient.get('/api/transactions');
+    return (Array.isArray(result) ? result : []).map(transformTransactionFromApi);
+  },
 
   // Create a new transaction
-  create: (transaction) => apiClient.post('/api/transactions', transaction),
+  create: async (transaction) => {
+    const result = await apiClient.post('/api/transactions', transaction);
+    return transformTransactionFromApi(result);
+  },
 
   // Get transactions by category
   getByCategory: (category) => apiClient.get(`/api/transactions/category/${category}`),

--- a/client/src/Services/transformers.js
+++ b/client/src/Services/transformers.js
@@ -1,0 +1,53 @@
+const splitCsvTags = (value) => {
+  if (Array.isArray(value)) {
+    return value
+      .flatMap((tag) => (typeof tag === 'string' ? tag.split(',') : []))
+      .map((tag) => tag.trim())
+      .filter(Boolean);
+  }
+
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((tag) => tag.trim())
+      .filter(Boolean);
+  }
+
+  return [];
+};
+
+export const normalizeTags = (tags) => splitCsvTags(tags);
+
+export const transformTransactionFromApi = (transaction = {}) => ({
+  ...transaction,
+  tags: normalizeTags(transaction.tags),
+  amount: Number.parseFloat(transaction.amount ?? 0) || 0,
+});
+
+export const makeQueueItemId = (item = {}, indexHint = 0) => {
+  const transaction = item?.transaction ?? {};
+
+  const parts = [
+    item?.sender,
+    item?.subject,
+    item?.email_datetime,
+    transaction?.amount,
+    transaction?.description,
+    item?.email,
+    transaction?.full_email,
+  ]
+    .map((part) => (part === undefined || part === null ? '' : String(part).trim()))
+    .filter(Boolean);
+
+  return parts.length > 0 ? parts.join('|') : `queue-item-${indexHint}`;
+};
+
+export const transformQueueItemFromApi = (item = {}, indexHint = 0) => {
+  const transaction = transformTransactionFromApi(item?.transaction ?? {});
+
+  return {
+    ...item,
+    transaction,
+    queueId: item?.queueId || makeQueueItemId(item, indexHint),
+  };
+};

--- a/client/src/components/EmailExtractionPage.jsx
+++ b/client/src/components/EmailExtractionPage.jsx
@@ -5,12 +5,13 @@ import { emailService } from '../Services/emailService';
 import { useTransactions } from '../hooks/useTransactions';
 import { AlertTriangle } from 'lucide-react';
 import EmailViewerModal from './common/EmailViewerModal';
+import { transformQueueItemFromApi } from '../Services/transformers';
 
 const EmailExtractionPage = () => {
   const { t } = useTranslation();
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
-  const [queue, setQueue] = useState([]); // {email, transaction}
+  const [queue, setQueue] = useState([]);
   const [selectedIds, setSelectedIds] = useState([]);
   const [loading, setLoading] = useState(false);
   const [processing, setProcessing] = useState(false);
@@ -25,8 +26,11 @@ const EmailExtractionPage = () => {
     setLoading(true);
     try {
       const data = await emailService.extractEmails(startDate, endDate);
-      setQueue(data || []);
-      setSelectedIds(data.map((_, idx) => idx));
+      const normalizedQueue = (Array.isArray(data) ? data : []).map((item, idx) =>
+        transformQueueItemFromApi(item, idx)
+      );
+      setQueue(normalizedQueue);
+      setSelectedIds(normalizedQueue.map((item) => item.queueId));
     } catch (err) {
       console.error(err);
       alert(err.message || 'Failed to extract emails');
@@ -35,35 +39,30 @@ const EmailExtractionPage = () => {
     }
   };
 
-
-  const toggleSelect = (idx) => {
+  const toggleSelect = (queueId) => {
     setSelectedIds((prev) =>
-      prev.includes(idx) ? prev.filter((id) => id !== idx) : [...prev, idx]
+      prev.includes(queueId) ? prev.filter((id) => id !== queueId) : [...prev, queueId]
     );
   };
 
   const selectAll = () => {
-    setSelectedIds(queue.map((_, idx) => idx));
+    setSelectedIds(queue.map((item) => item.queueId));
   };
 
   const clearSelection = () => setSelectedIds([]);
 
   const removeSelected = () => {
-    setQueue((prev) => prev.filter((_, idx) => !selectedIds.includes(idx)));
+    setQueue((prev) => prev.filter((item) => !selectedIds.includes(item.queueId)));
     setSelectedIds([]);
   };
 
-  const removeFromQueue = (idxToRemove) => {
-    setQueue((prev) => prev.filter((_, idx) => idx !== idxToRemove));
-    setSelectedIds((prev) =>
-      prev
-        .filter((id) => id !== idxToRemove)
-        .map((id) => (id > idxToRemove ? id - 1 : id))
-    );
+  const removeFromQueue = (queueIdToRemove) => {
+    setQueue((prev) => prev.filter((item) => item.queueId !== queueIdToRemove));
+    setSelectedIds((prev) => prev.filter((id) => id !== queueIdToRemove));
   };
 
   const viewEmail = (html) => {
-    setModalHtml(html);
+    setModalHtml(html || '');
     setShowEmailModal(true);
   };
 
@@ -85,14 +84,19 @@ const EmailExtractionPage = () => {
       const processed = await emailService.processQueue(emails);
       if (Array.isArray(processed)) {
         const messages = processed
-          .filter(p => p.applied_rules && p.applied_rules.length > 0)
-          .map(p => `${p.transaction?.description || p.description}: ${p.applied_rules.map(r => r.keyword).join(', ')}`);
+          .filter((p) => p.applied_rules && p.applied_rules.length > 0)
+          .map(
+            (p) =>
+              `${p.transaction?.description || p.description || 'Unknown'}: ${p.applied_rules
+                .map((r) => r.keyword)
+                .join(', ')}`
+          );
         if (messages.length > 0) {
           alert(`Applied rules:\n${messages.join('\n')}`);
         }
       }
       setProgress(emails.length);
-      setQueue((prev) => prev.filter((q) => !emails.includes(q.email)));
+      setQueue((prev) => prev.filter((item) => !emails.includes(item.email)));
       setSelectedIds([]);
       await refreshTransactions();
     } catch (err) {
@@ -105,20 +109,20 @@ const EmailExtractionPage = () => {
 
   const processSelected = () => {
     const emails = queue
-      .filter((_, idx) => selectedIds.includes(idx))
-      .map((q) => q.email);
+      .filter((item) => selectedIds.includes(item.queueId))
+      .map((item) => item.email)
+      .filter(Boolean);
     processEmails(emails);
   };
 
   const processAll = () => {
-    const emails = queue.map((q) => q.email);
+    const emails = queue.map((item) => item.email).filter(Boolean);
     processEmails(emails);
   };
 
-  const allSelected =
-    queue.length > 0 && queue.every((_, idx) => selectedIds.includes(idx));
+  const allSelected = queue.length > 0 && queue.every((item) => selectedIds.includes(item.queueId));
 
-  const duplicateCount = queue.filter((q) => q.transaction.duplicate).length;
+  const duplicateCount = queue.filter((item) => Boolean(item?.transaction?.duplicate)).length;
   const selectedCount = selectedIds.length;
 
   return (
@@ -210,44 +214,46 @@ const EmailExtractionPage = () => {
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200">
-              {queue.map((item, idx) => (
-                <tr
-                  key={idx}
-                  className={item.transaction.duplicate ? 'bg-yellow-50' : ''}
-                >
-                  <td className="px-6 py-4">
-                    <input
-                      type="checkbox"
-                      checked={selectedIds.includes(idx)}
-                      onChange={() => toggleSelect(idx)}
-                    />
-                  </td>
-                  <td className="px-6 py-4">{item.transaction.date}</td>
-                  <td className="px-6 py-4">{item.transaction.amount}</td>
-                  <td className="px-6 py-4">{item.transaction.description}</td>
-                  <td className="px-6 py-4">{item.transaction.bank}</td>
-                  <td className="px-6 py-4">
-                    <button
-                      onClick={() => viewEmail(item.transaction.full_email)}
-                      className="text-blue-600 hover:underline"
-                    >
-                      {t('queue.table.viewEmail')}
-                    </button>
-                  </td>
-                  <td className="px-6 py-4 text-red-600 flex items-center gap-1">
-                    {item.transaction.duplicate && <AlertTriangle className="w-4 h-4" />}
-                    {item.transaction.duplicate ? t('queue.table.duplicateYes') : t('queue.table.duplicateNo')}
-                  </td>
-                  <td className="px-6 py-4">
-                    <button
-                      onClick={() => removeFromQueue(idx)}
-                      className="text-red-600 hover:text-red-800"
-                    >
-                      {t('queue.table.remove')}
-                    </button>
-                  </td>
-                </tr>
-              ))}
+              {queue.map((item) => {
+                const transaction = item?.transaction || {};
+                const isDuplicate = Boolean(transaction.duplicate);
+
+                return (
+                  <tr key={item.queueId} className={isDuplicate ? 'bg-yellow-50' : ''}>
+                    <td className="px-6 py-4">
+                      <input
+                        type="checkbox"
+                        checked={selectedIds.includes(item.queueId)}
+                        onChange={() => toggleSelect(item.queueId)}
+                      />
+                    </td>
+                    <td className="px-6 py-4">{transaction.date || item.email_datetime || '-'}</td>
+                    <td className="px-6 py-4">{transaction.amount ?? '-'}</td>
+                    <td className="px-6 py-4">{transaction.description || item.subject || '-'}</td>
+                    <td className="px-6 py-4">{transaction.bank || '-'}</td>
+                    <td className="px-6 py-4">
+                      <button
+                        onClick={() => viewEmail(transaction.full_email || item.email || '')}
+                        className="text-blue-600 hover:underline"
+                      >
+                        {t('queue.table.viewEmail')}
+                      </button>
+                    </td>
+                    <td className="px-6 py-4 text-red-600 flex items-center gap-1">
+                      {isDuplicate && <AlertTriangle className="w-4 h-4" />}
+                      {isDuplicate ? t('queue.table.duplicateYes') : t('queue.table.duplicateNo')}
+                    </td>
+                    <td className="px-6 py-4">
+                      <button
+                        onClick={() => removeFromQueue(item.queueId)}
+                        className="text-red-600 hover:text-red-800"
+                      >
+                        {t('queue.table.remove')}
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
           {processing && (

--- a/client/src/components/Sections/TransactionTable.jsx
+++ b/client/src/components/Sections/TransactionTable.jsx
@@ -189,9 +189,9 @@ const EditableTransactionRow = ({
       {/* Tags - Clean badge display only (editing through modal) */}
       <td className="px-8 py-6 whitespace-nowrap">
         <div className="flex flex-wrap gap-1">
-          {transaction.tags && transaction.tags.split(',').map(tag => tag.trim()).filter(tag => tag).map((tag, index) => (
+          {Array.isArray(transaction.tags) && transaction.tags.map((tag, index) => (
             <span
-              key={index}
+              key={`${transaction.id}-${tag}-${index}`}
               className={`px-2 py-1 text-xs rounded-full transition-all duration-200 ${
                 filters.tags.includes(tag)
                   ? 'bg-green-100 text-green-800 ring-2 ring-green-200'
@@ -201,7 +201,7 @@ const EditableTransactionRow = ({
               {tag}
             </span>
           ))}
-          {(!transaction.tags || transaction.tags.split(',').filter(tag => tag.trim()).length === 0) && (
+          {(!Array.isArray(transaction.tags) || transaction.tags.length === 0) && (
             <span className="px-2 py-1 text-xs rounded-full bg-gray-100 text-gray-500">
               No tags
             </span>

--- a/client/src/components/TransactionDashboard.jsx
+++ b/client/src/components/TransactionDashboard.jsx
@@ -17,6 +17,7 @@ import TagEditModal from './common/TagEditModal';
 import { useCategories } from '../hooks/useCategories';
 import { useTags } from '../hooks/useTags';
 import { transactionService } from '../Services/transactionService';
+import { transformTransactionFromApi } from '../Services/transformers';
 
 
 const TransactionDashboard = () => {
@@ -44,32 +45,28 @@ const {
   refreshTags 
 } = useTags();
 
-const [useRealData, setUseRealData] = useState(false);
+const [useRealData, setUseRealData] = useState(true);
 
 
 React.useEffect(() => {
-  if (useRealData && realTransactions.length > 0) {
+  if (useRealData) {
     console.log('🔄 Switching to real data...', realTransactions.length, 'transactions');
     setTransactions(realTransactions);
-  } else if (!useRealData) {
+  } else {
     console.log('🔄 Using mock data...');
-    setTransactions(generateMockData());
+    setTransactions(generateMockData().map(transformTransactionFromApi));
   }
 }, [useRealData, realTransactions]);
 
 
 React.useEffect(() => {
-  if (realCategories.length > 0) {
-    console.log('📊 Updating categories from API:', realCategories);
-    setLocalCategories(realCategories);
-  }
+  console.log('📊 Updating categories from API:', realCategories);
+  setLocalCategories(Array.isArray(realCategories) ? realCategories : []);
 }, [realCategories]);
 
 React.useEffect(() => {
-  if (realTags.length > 0) {
-    console.log('🏷️ Updating tags from API:', realTags);
-    setLocalTags(realTags);
-  }
+  console.log('🏷️ Updating tags from API:', realTags);
+  setLocalTags(Array.isArray(realTags) ? realTags : []);
 }, [realTags]);
 
 
@@ -81,7 +78,7 @@ const { expandedSections, toggleSection } = useExpandableState({
   });
 
 
-  const [transactions, setTransactions] = useState(generateMockData());
+  const [transactions, setTransactions] = useState([]);
   const [activeSettingsTab, setActiveSettingsTab] = useState('display');
   const [chartType, setChartType] = useState('bar');
   const [itemsPerPage, setItemsPerPage] = useState(20);
@@ -128,8 +125,8 @@ const [filters, setFilters] = useState({
 });
 
 
-const uniqueCategories = [...new Set(transactions.map(t => t.category))];
-  const uniqueTags = [...new Set(transactions.map(t => t.tags).filter(t => t))];
+const uniqueCategories = [...new Set(transactions.map(t => t.category).filter(Boolean))];
+  const uniqueTags = [...new Set(transactions.flatMap(t => (Array.isArray(t.tags) ? t.tags : [])).filter(Boolean))];
   const uniqueCardTypes = [...new Set(transactions.map(t => t.bank).filter(t => t))]; 
 
   const [showTagModal, setShowTagModal] = useState(false);
@@ -143,9 +140,9 @@ const filteredTransactions = useMemo(() => {
     if (filters.dateTo && transaction.date > filters.dateTo) return false;
     if (filters.amountMin && transaction.amount < parseFloat(filters.amountMin)) return false;
     if (filters.amountMax && transaction.amount > parseFloat(filters.amountMax)) return false;
-    if (filters.keyword && !transaction.description.toLowerCase().includes(filters.keyword.toLowerCase())) return false;
+    if (filters.keyword && !(transaction.description || '').toLowerCase().includes(filters.keyword.toLowerCase())) return false;
     if (filters.categories.length > 0 && !filters.categories.includes(transaction.category)) return false;
-    if (filters.tags.length > 0 && !filters.tags.includes(transaction.tags)) return false;
+    if (filters.tags.length > 0 && !filters.tags.some((tag) => transaction.tags?.includes(tag))) return false;
     if (filters.banks.length > 0 && !filters.banks.includes(transaction.bank)) return false; // ← CHANGE THIS LINE
 
     return true;
@@ -314,13 +311,13 @@ const handleStartEdit = (transaction, field) => {
   setEditingTransaction(`${transaction.id}-${field}`);
   setEditValues({
     [field]: field === 'tags' 
-      ? transaction.tags.split(',').map(t => t.trim()).filter(t => t) 
+      ? (Array.isArray(transaction.tags) ? transaction.tags : []) 
       : transaction[field]
   });
   
   console.log('✅ Editing state set:', {
     editingTransaction: `${transaction.id}-${field}`,
-    editValues: { [field]: field === 'tags' ? transaction.tags.split(',').map(t => t.trim()).filter(t => t) : transaction[field] }
+    editValues: { [field]: field === 'tags' ? (Array.isArray(transaction.tags) ? transaction.tags : []) : transaction[field] }
   });
 };
 
@@ -413,9 +410,10 @@ const handleEditItem = (type, oldName, newName) => {
     ));
   } else if (type === 'tag') {
     setLocalTags(prev => prev.map(tag => tag === oldName ? newName : tag));       // ← Changed
-    setTransactions(prev => prev.map(t => 
-      t.tags === oldName ? { ...t, tags: newName } : t
-    ));
+    setTransactions(prev => prev.map(t => ({
+      ...t,
+      tags: Array.isArray(t.tags) ? t.tags.map(tag => (tag === oldName ? newName : tag)) : []
+    })));
   }
   setEditingItem(null);
 };
@@ -433,7 +431,7 @@ const handleEditItem = (type, oldName, newName) => {
       const result = await transactionService.create(newTransaction);
       if (result.applied_rules && result.applied_rules.length > 0) {
         const msg = result.applied_rules
-          .map(r => `${r.keyword} → ${r.category || ''}${r.tags.length ? ' [' + r.tags.join(', ') + ']' : ''}`)
+          .map(r => `${r.keyword} → ${r.category || ''}${Array.isArray(r.tags) && r.tags.length ? ' [' + r.tags.join(', ') + ']' : ''}`)
           .join('\n');
         alert(`Applied rules:\n${msg}`);
       }

--- a/client/src/components/common/TagEditModal.jsx
+++ b/client/src/components/common/TagEditModal.jsx
@@ -33,9 +33,7 @@ const TagEditModal = ({
   // Initialize current tags when modal opens
   useEffect(() => {
     if (isOpen && transaction) {
-      const transactionTags = transaction.tags 
-        ? transaction.tags.split(',').map(tag => tag.trim()).filter(tag => tag)
-        : [];
+      const transactionTags = Array.isArray(transaction.tags) ? transaction.tags : [];
       setCurrentTags(transactionTags);
     }
   }, [isOpen, transaction]);

--- a/client/src/hooks/useTransactions.js
+++ b/client/src/hooks/useTransactions.js
@@ -17,16 +17,7 @@ export const useTransactions = () => {
       setError(null);
       const data = await transactionService.getAll();
       
-      // Transform data to match your existing format
-      const transformedData = data.map(transaction => ({
-        ...transaction,
-        // Ensure tags is a string (your API returns comma-separated tags)
-        tags: transaction.tags || '',
-        // Ensure amount is a number
-        amount: parseFloat(transaction.amount)
-      }));
-      
-      setTransactions(transformedData);
+      setTransactions(Array.isArray(data) ? data : []);
     } catch (err) {
       console.error('Error loading transactions:', err);
       setError(err.message);


### PR DESCRIPTION
### Motivation
- Normalize transaction shape coming from the API (tags as arrays, numeric `amount`) and centralize transformations for consistent client usage.
- Make email queue items have stable IDs to allow selection, removal, and processing without relying on array indices.
- Move the UI away from comma-separated tag strings to array-based tags and make filtering/edits robust against missing or malformed data.

### Description
- Added `client/src/Services/transformers.js` with `transformTransactionFromApi`, `normalizeTags`, `transformQueueItemFromApi`, and helpers to convert API responses into the app's expected shapes and to generate stable `queueId` values.
- Updated `transactionService` to run `getAll` and `create` through `transformTransactionFromApi` so the hook and components receive normalized objects (tags array, numeric amount).
- Modified `EmailExtractionPage` to use `transformQueueItemFromApi`, to track selections by `queueId` (not index), and to safely render fallback fields (e.g. `email_datetime`, `subject`, `full_email`), and to properly remove/process items by `queueId`.
- Updated `TransactionTable`, `TagEditModal`, and `TransactionDashboard` to expect `transaction.tags` as an array and to handle tags/categories safely with `Array.isArray` checks and defensive defaults; improved unique tag/category extraction and filtering logic.
- Simplified `useTransactions` to accept normalized data from the service and set transactions directly instead of re-transforming CSV tags.
- Minor UX/logging tweaks and safer string/number handling across the dashboard and add-transaction flow.

### Testing
- Ran linter and unit tests locally with `npm run lint` and `npm test` and observed the test suite passing with no regressions.
- Performed a local frontend build with `npm run build` to ensure the app compiles successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf1a643424832b8649ed6f3c933d8a)