### PR TITLE
Patch 3: unify transaction contract and reduce extract/process drift

### DIFF
--- a/Application/api_scripts/process_queue.py
+++ b/Application/api_scripts/process_queue.py
@@ -10,6 +10,41 @@ sys.path.append(os.path.abspath(os.path.join(current_dir, '..', '..')))
 from traitement import extract_transaction_data
 from Database.Insert import insert_transaction
 
+def _source_ref_from_email(email_payload):
+    if not isinstance(email_payload, dict):
+        return None
+    parts = [email_payload.get("sender"), email_payload.get("subject"), email_payload.get("email_datetime")]
+    cleaned = [str(p).strip() for p in parts if p]
+    return "|".join(cleaned) if cleaned else None
+
+def _normalize_queue_item(item):
+    """Return a normalized transaction candidate from a queue item."""
+    if not isinstance(item, dict):
+        return None
+
+    parsed_transaction = item.get("transaction")
+    email_payload = item.get("email") if isinstance(item.get("email"), dict) else item
+
+    # Reuse preview parsing when available to reduce parser drift.
+    if isinstance(parsed_transaction, dict) and parsed_transaction.get("amount") is not None:
+        trans = dict(parsed_transaction)
+        trans.setdefault("source_type", "email")
+        trans.setdefault("source_ref", email_payload.get("id") or _source_ref_from_email(email_payload))
+        trans.setdefault("full_email", email_payload.get("full_email_html") or email_payload.get("email"))
+        trans.setdefault("tags", [])
+        return trans
+
+    # Fallback for legacy callers that only submit the raw email payload.
+    trans = extract_transaction_data(
+        email_payload,
+        email_payload.get("sender"),
+        email_payload.get("subject"),
+        email_payload.get("email_datetime"),
+    )
+    trans.setdefault("source_type", "email")
+    trans.setdefault("source_ref", email_payload.get("id") or _source_ref_from_email(email_payload))
+    trans.setdefault("tags", [])
+    return trans
 
 def main():
     raw = sys.stdin.read()
@@ -24,14 +59,16 @@ def main():
 
     results = []
     for email in emails:
-        trans = extract_transaction_data(
-            email, email.get('sender'), email.get('subject'), email.get('email_datetime')
-        )
+        trans = _normalize_queue_item(email)
+        if not trans:
+            continue
         insert_result = insert_transaction(trans)
         if isinstance(insert_result, dict):
             trans['category'] = insert_result.get('category', trans.get('category'))
             trans['tags'] = insert_result.get('tags', trans.get('tags', []))
             trans['applied_rules'] = insert_result.get('applied_rules', [])
+            trans['source_type'] = insert_result.get('source_type', trans.get('source_type'))
+            trans['source_ref'] = insert_result.get('source_ref', trans.get('source_ref'))
         results.append(trans)
     print(json.dumps(results))
 

--- a/Application/tests/test_ingestion_contract.py
+++ b/Application/tests/test_ingestion_contract.py
@@ -1,0 +1,60 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+from traitement import extract_transaction_data
+from api_scripts import process_queue
+from Database.Insert import normalize_tags
+
+
+def test_extract_transaction_contract_uses_card_type_and_source_metadata():
+    result = extract_transaction_data(
+        {
+            "sender": "capitalone@notification.capitalone.com",
+            "subject": "A transaction was charged to your account",
+            "email_datetime": "Fri, 03 Apr 2026 12:00:00 +0000",
+            "bank_config": "capital_one_credit",
+            "full_email_html": "Store Name $10.00",
+        }
+    )
+
+    assert "card_type" in result
+    assert result["card_type"] == "credit card"
+    assert result["card type"] == result["card_type"]  # legacy alias
+    assert result["source_type"] == "email"
+    assert isinstance(result["source_ref"], str)
+    assert isinstance(result["tags"], list)
+
+
+def test_process_queue_reuses_preview_transaction_when_present():
+    queue_item = {
+        "email": {
+            "sender": "sender@example.com",
+            "subject": "Subject",
+            "email_datetime": "Fri, 03 Apr 2026 12:00:00 +0000",
+            "full_email_html": "ignored",
+        },
+        "transaction": {
+            "amount": "41.11",
+            "description": "Preview Vendor",
+            "card_type": "credit card",
+            "date": "2026-04-03",
+            "bank": "capital_one_credit",
+            "full_email": "preview copy",
+        },
+    }
+
+    normalized = process_queue._normalize_queue_item(queue_item)
+
+    assert normalized["amount"] == "41.11"
+    assert normalized["description"] == "Preview Vendor"
+    assert normalized["full_email"] == "preview copy"
+    assert normalized["source_type"] == "email"
+    assert isinstance(normalized["tags"], list)
+
+
+def test_normalize_tags_accepts_csv_and_arrays():
+    assert normalize_tags("food, transport , food") == ["food", "transport"]
+    assert normalize_tags(["one, two", "two", "three"]) == ["one", "two", "three"]

--- a/Application/traitement.py
+++ b/Application/traitement.py
@@ -64,6 +64,24 @@ def _contains_exclude_keyword(bank_cfg: dict, subject: str, content: str) -> boo
     return False
 
 
+def _build_source_ref(email_payload: dict | None) -> str | None:
+    """Create a stable source reference for ingestion tracing."""
+    if not isinstance(email_payload, dict):
+        return None
+
+    explicit_ref = email_payload.get("id") or email_payload.get("source_ref")
+    if explicit_ref:
+        return str(explicit_ref)
+
+    parts = [
+        email_payload.get("sender"),
+        email_payload.get("subject"),
+        email_payload.get("email_datetime"),
+    ]
+    cleaned = [str(p).strip() for p in parts if p]
+    return "|".join(cleaned) if cleaned else None
+
+
 def extract_transaction_data(
     email_data,
     email_sender: str | None = None,
@@ -149,11 +167,17 @@ def extract_transaction_data(
     ordered_data = {
         "amount": extracted_data.get("amount"),
         "description": extracted_data.get("description"),
+        "card_type": extracted_data.get("card_type"),
+        # Backward compatibility for old consumers still reading "card type"
         "card type": extracted_data.get("card_type"),
         "date": formatted_date.split(" ")[0] if formatted_date else None,
         "time": formatted_date.split(" ")[1] if formatted_date else None,
         "bank": bank_name,
         "full_email": html if html else email_text,
+        # Explicit contract defaults
+        "tags": [],
+        "source_type": "email",
+        "source_ref": _build_source_ref(email_data if isinstance(email_data, dict) else None),
     }
 
     dup = False

--- a/Database/Database.py
+++ b/Database/Database.py
@@ -8,6 +8,8 @@ def _check_and_update_columns(cursor):
         "bank": "TEXT NOT NULL",
         "full_email": "TEXT DEFAULT 'No email content'",
         "category": "TEXT DEFAULT 'Uncategorized'",
+        "source_type": "TEXT DEFAULT 'manual'",
+        "source_ref": "TEXT DEFAULT NULL",
         "created_at": "TIMESTAMP DEFAULT CURRENT_TIMESTAMP",
     }
 
@@ -41,6 +43,8 @@ def create_database():
             bank TEXT NOT NULL,
             full_email TEXT DEFAULT 'No email content',
             category TEXT DEFAULT 'Uncategorized',
+            source_type TEXT DEFAULT 'manual',
+            source_ref TEXT DEFAULT NULL,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )
     """)
@@ -88,4 +92,3 @@ def create_database():
 
 # Run the function to create/update the database schema
 create_database()
-

--- a/Database/Insert.py
+++ b/Database/Insert.py
@@ -7,6 +7,30 @@ if not logging.getLogger().handlers:
     logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+def normalize_tags(tags):
+    """Normalize tags to a de-duplicated list of strings."""
+    if tags is None:
+        return []
+
+    if isinstance(tags, str):
+        values = tags.split(",")
+    elif isinstance(tags, list):
+        values = []
+        for item in tags:
+            if isinstance(item, str):
+                values.extend(item.split(","))
+    else:
+        return []
+
+    normalized = []
+    seen = set()
+    for tag in values:
+        cleaned = tag.strip()
+        if cleaned and cleaned not in seen:
+            seen.add(cleaned)
+            normalized.append(cleaned)
+    return normalized
+
 def apply_keyword_rules(cursor, description, category, tags):
     """Apply keyword-based rules to set category and tags and return matched rules."""
     cursor.execute(
@@ -57,16 +81,20 @@ def insert_transaction(ordered_data):
         category = ordered_data.get("category", "Uncategorized")
 
         # ✅ Apply keyword rules for automatic category and tags
-        card_type = ordered_data.get("card type") or ordered_data.get("card_type")
-        tags = ordered_data.get("tags", [])
+        card_type = ordered_data.get("card_type") or ordered_data.get("card type")
+        tags = normalize_tags(ordered_data.get("tags", []))
         category, tags, matched_rules = apply_keyword_rules(
             cursor, ordered_data["description"], category, tags
         )
+        source_type = ordered_data.get("source_type", "manual")
+        source_ref = ordered_data.get("source_ref")
 
         # ✅ Get or create transaction entry
         cursor.execute("""
-            INSERT INTO transactions (amount, description, card_type, date, time, bank, full_email, category)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO transactions (
+                amount, description, card_type, date, time, bank, full_email, category, source_type, source_ref
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, (
             amount,
             ordered_data["description"],
@@ -75,7 +103,9 @@ def insert_transaction(ordered_data):
             ordered_data.get("time", None),  # ✅ Allow NULL time
             ordered_data["bank"],
             ordered_data.get("full_email", "No email content"),
-            category
+            category,
+            source_type,
+            source_ref,
         ))
 
         # ✅ Get the inserted transaction ID
@@ -100,6 +130,8 @@ def insert_transaction(ordered_data):
             "category": category,
             "tags": tags,
             "applied_rules": matched_rules,
+            "source_type": source_type,
+            "source_ref": source_ref,
         }
 
     except ValueError:

--- a/client/src/components/EmailExtractionPage.jsx
+++ b/client/src/components/EmailExtractionPage.jsx
@@ -76,12 +76,12 @@ const EmailExtractionPage = () => {
     setSelectedIds([]);
   };
 
-  const processEmails = async (emails) => {
-    if (emails.length === 0) return;
+  const processEmails = async (queueItems) => {
+    if (queueItems.length === 0) return;
     setProcessing(true);
     setProgress(0);
     try {
-      const processed = await emailService.processQueue(emails);
+      const processed = await emailService.processQueue(queueItems);
       if (Array.isArray(processed)) {
         const messages = processed
           .filter((p) => p.applied_rules && p.applied_rules.length > 0)
@@ -95,8 +95,11 @@ const EmailExtractionPage = () => {
           alert(`Applied rules:\n${messages.join('\n')}`);
         }
       }
-      setProgress(emails.length);
-      setQueue((prev) => prev.filter((item) => !emails.includes(item.email)));
+      setProgress(queueItems.length);
+      const processedIds = new Set(
+        queueItems.map((item) => item.queueId).filter(Boolean)
+      );
+      setQueue((prev) => prev.filter((item) => !processedIds.has(item.queueId)));
       setSelectedIds([]);
       await refreshTransactions();
     } catch (err) {
@@ -108,16 +111,14 @@ const EmailExtractionPage = () => {
   };
 
   const processSelected = () => {
-    const emails = queue
+    const selectedItems = queue
       .filter((item) => selectedIds.includes(item.queueId))
-      .map((item) => item.email)
       .filter(Boolean);
-    processEmails(emails);
+    processEmails(selectedItems);
   };
 
   const processAll = () => {
-    const emails = queue.map((item) => item.email).filter(Boolean);
-    processEmails(emails);
+    processEmails(queue);
   };
 
   const allSelected = queue.length > 0 && queue.every((item) => selectedIds.includes(item.queueId));


### PR DESCRIPTION
### Motivation
- Reduce contract drift between email preview and insertion paths so previewed extractions match inserted transactions.
- Make `card_type` the canonical parser field while preserving backward-compatible aliases and normalizing tag shapes.
- Introduce lightweight, backward-compatible source metadata to support future mailbox/OCR ingestion without redesigning transactions.
- Keep the existing architecture (Express → Python subprocess → SQLite) and make minimal, incremental changes.

### Description
- Normalize parser output in `Application/traitement.py` to emit `card_type` (while still providing the legacy `"card type"` alias), add explicit `tags` default, `source_type`, and compute `source_ref` via `_build_source_ref`.
- Reduce preview/insert drift by adding `_normalize_queue_item` and `_source_ref_from_email` to `Application/api_scripts/process_queue.py` so the process flow reuses the previewed `transaction` payload when present and falls back to `extract_transaction_data` for legacy/raw payloads.
- Centralize tag normalization with `normalize_tags()` in `Database/Insert.py`, accept CSV or array inputs, use canonical `card_type` when inserting, persist `source_type`/`source_ref`, and include them in the insert response; keyword-rule application now works against the canonical tag list.
- Add backward-compatible schema support in `Database/Database.py` for `source_type` and `source_ref` and ensure `ALTER TABLE` upgrades for older DBs.
- Update the frontend queue flow in `client/src/components/EmailExtractionPage.jsx` to send full queue items (including previewed `transaction`) to the process endpoint and to remove processed queue items by `queueId` for consistent UX.
- Add focused tests in `Application/tests/test_ingestion_contract.py` to assert contract shape (canonical `card_type`, `source_type`, `source_ref`, `tags`) and that `_normalize_queue_item` reuses previewed transactions.

### Testing
- Ran unit tests: `pytest -q Application/tests/test_description_extraction.py Application/tests/test_ingestion_contract.py` and all tests passed (10 passed, 0 failed).
- The new tests validate the parser contract (card_type + legacy alias), source metadata defaults, tag normalization behavior, and that process-queue reuses previewed parsed transactions when provided.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf1f9c11b0832b849f5eb41d0aadb9)